### PR TITLE
Add support for slashes in file_filter even on Windows.

### DIFF
--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -202,7 +202,7 @@ def _auto_local(path_to_tx, resource, source_language, expression, execute=False
     for root, dirs, files in os.walk(curpath):
         for f in files:
             f_path = os.path.abspath(os.path.join(root, f))
-            match = expr_rec.match(f_path)
+            match = expr_rec.match(f_path.replace('\\', '/'))
             if match:
                 lang = match.group(1)
                 f_path = os.path.abspath(f_path)

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -221,7 +221,7 @@ class Project(object):
             for root, dirs, files in os.walk(self.root):
                 for f in files:
                     f_path = os.path.abspath(os.path.join(root, f))
-                    match = expr_rec.match(f_path)
+                    match = expr_rec.match(f_path.replace('\\', '/'))
                     if match:
                         lang = match.group(1)
                         if lang != source_lang:

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -33,13 +33,11 @@ def find_dot_tx(path = os.path.curdir, previous = None):
 
 def regex_from_filefilter(file_filter, root_path = os.path.curdir):
     """
-    Create proper regex from <lang> expression
+    Create proper regex from <lang> expression, normalized to posix paths.
     """
     # Force expr to be a valid regex expr (escaped) but keep <lang> intact
-    expr_re = re.escape(os.path.join(root_path, file_filter))
-    expr_re = expr_re.replace("\\<lang\\>", '<lang>').replace(
-        '<lang>', '([^%(sep)s]+)' % { 'sep': re.escape(os.path.sep)})
-
+    expr_re = re.escape(os.path.join(root_path, file_filter).replace('\\', '/'))
+    expr_re = expr_re.replace('\\<lang\\>', '([^/]+)')
     return "^%s$" % expr_re
 
 


### PR DESCRIPTION
Hello Transifex developers,

In our project, we added the `.tx/config` file to the repository.

The file looks like this:

```
[main]
host = https://www.transifex.com

...
[trac.trunk-messages-pot]
file_filter = trac/locale/<lang>/LC_MESSAGES/messages.po
source_file = trac/locale/messages.pot
source_lang = en
...
```

However the `file_filter` is not effective on Windows, where `tx` expects `\`. Not surprisingly, if we would change that to `\`, the `tx` clients on Linux would fail...

IMO, best thing would be to also support `/` as a path separator on Windows, which is common practice anyway.

All test cases still pass (on the 0.8 variant of the patch, as the tests couldn't be run on the 0.7.x branch for some reason), and I verified that a `.tx/config` file containing `\` still works on Windows, so the proposed change is backward compatible for Windows-only people.

The only possible downside of the patch is that a `\` in the `file_filter` will also be replaced by a `/` on Linux. I don't think this can be a problem in practice, but if this is really an issue, then maybe we can do the `\` -> `/` replacement on Windows only.
