### PR TITLE
Escape UTF characters

### DIFF
--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -344,6 +344,7 @@ def cmd_pull(argv, path_to_tx):
     resources = parse_csv_option(options.resources)
     skip = options.skip_errors
     minimum_perc = options.minimum_perc or None
+    escape_utf = options.escape_utf
 
     try:
         _go_to_dir(path_to_tx)
@@ -357,7 +358,7 @@ def cmd_pull(argv, path_to_tx):
         languages=languages, resources=resources, overwrite=options.overwrite,
         fetchall=options.fetchall, fetchsource=options.fetchsource,
         force=options.force, skip=skip, minimum_perc=minimum_perc,
-        mode=options.mode
+        mode=options.mode, escape_utf=escape_utf
     )
     logger.info("Done.")
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -112,6 +112,11 @@ def pull_parser():
             "'reviewed'). See http://bit.ly/txcmod1 for available values."
         )
     )
+    parser.add_option("--escape-utf", action="store_true",
+            dest="escape_utf", default=False, help="If you need ASCII files"\
+            " including utf characters, this option escapes them using "\
+            "\\uXXXX representation.")
+
     return parser
 
 


### PR DESCRIPTION
We added a new command line option to escape utf-8 characters in a translation file
using \uXXXX format.
This can be invoked using the new command line option --escape-utf.
This is useful if you have utf-8 characters in a non utf java properties file.
