### PR TITLE
Ship tests in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,6 @@ include txclib/cacert.pem
 include LICENSE README.rst
 recursive-include docs *
 
+# Tests
+recursive-include tests *
+


### PR DESCRIPTION
While it doesn't make sense to install tests system-wide, they should be
shipped in the source distribution. This way people can run it when they
use tarballs from PyPI (e.g. during RPM builds).
