### PR TITLE
Log not found languages files instead of raising a KeyError

### DIFF
--- a/txclib/project.py
+++ b/txclib/project.py
@@ -652,7 +652,14 @@ class Project(object):
                     else:
                         remote_lang = lang
 
-                    local_file = files[local_lang]
+                    try:
+                        local_file = files[local_lang]
+                    except KeyError as e:
+                        msg = "No translation file found for language code '%s' in resource '%s'"
+                        logger.error(msg % (color_text(local_lang, "RED"), resource_slug))
+                        if not skip:
+                            raise e
+                        continue
 
                     kwargs = {
                         'lang': remote_lang,


### PR DESCRIPTION
If for a resource, a translation file is not present, it should be logged but
not interrupt the upload (or at least not with a traceback)

**How to reproduce**
* create a project with two resources
* add french translation file in the second resource one but not in the first
* execute `tx push -t -l fr --skip`

**Expected**
* translation of the second resource pushed to server

**Actual**
* KeyError and the program exist

In my workflow, we add translation files only once at least one word is translated so new resources will not contains any translation files at first.