### PR TITLE
Use local .transifexrc file if it exists

### DIFF
--- a/txclib/project.py
+++ b/txclib/project.py
@@ -48,11 +48,13 @@ class Project(object):
             self.root = self._get_tx_dir_path(path_to_tx)
             self.config_file = self._get_config_file_path(self.root)
             self.config = self._read_config_file(self.config_file)
-            self.txrc_file = self._get_transifex_file()
+            
             local_txrc_file = self._get_transifex_file(os.getcwd())
-            self.txrc = self._get_transifex_config([self.txrc_file, local_txrc_file])
             if os.path.exists(local_txrc_file):
                 self.txrc_file = local_txrc_file
+            else:
+                self.txrc_file = self._get_transifex_file()
+            self.txrc = self._get_transifex_config([self.txrc_file, ])
         except ProjectNotInit as e:
             logger.error('\n'.join([six.u(str(e)), instructions]))
             raise


### PR DESCRIPTION
If a local .transifexrc file exists it is used instead of the user-level file. This behavior makes more sense than merging the two config files.