### PR TITLE
SSL fixes for Windows

### DIFF
--- a/tx
+++ b/tx
@@ -92,8 +92,6 @@ def main(argv):
     cmd = args[0]
     try:
         utils.exec_command(cmd, args[1:], path_to_tx)
-    except SSLError as e:
-        sys.exit(1)
     except utils.UnknownCommandError:
         logger.error("tx: Command %s not found" % cmd)
     except SystemExit:

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -9,7 +9,6 @@ except ImportError:
     from simplejson import loads as parse_json, dumps as compile_json
 
 from email.parser import Parser
-from urllib3.exceptions import SSLError
 from urllib3.packages import six
 from urllib3.packages.six.moves import input
 from txclib.urls import API_URLS
@@ -128,9 +127,6 @@ def make_request(method, host, url, username, password, fields=None):
             else:
                 raise Exception(data)
         return data, charset
-    except SSLError:
-        logger.error("Invalid SSL certificate")
-        raise
     finally:
         if not r is None:
             r.close()

--- a/txclib/web.py
+++ b/txclib/web.py
@@ -13,29 +13,30 @@ def user_agent_identifier():
 
 
 def certs_file():
-    if platform.system() == 'Windows':
-        return os.path.join(txclib.utils.get_base_dir(), 'txclib', 'cacert.pem')
-    else:
-        POSSIBLE_CA_BUNDLE_PATHS = [
-            # Red Hat, CentOS, Fedora and friends
-            # (provided by the ca-certificates package):
-            '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
-            '/etc/ssl/certs/ca-bundle.crt',
-            '/etc/pki/tls/certs/ca-bundle.crt',
-            # Ubuntu, Debian, and friends
-            # (provided by the ca-certificates package):
-            '/etc/ssl/certs/ca-certificates.crt',
-            # FreeBSD (provided by the ca_root_nss package):
-            '/usr/local/share/certs/ca-root-nss.crt',
-            # openSUSE (provided by the ca-certificates package),
-            # the 'certs' directory is the
-            # preferred way but may not be supported by the SSL module,
-            # thus it has 'ca-bundle.pem'
-            # as a fallback (which is generated from pem files in the
-            # 'certs' directory):
-            '/etc/ssl/ca-bundle.pem',
-        ]
-        for path in POSSIBLE_CA_BUNDLE_PATHS:
-            if os.path.exists(path):
-                return path
-        return resource_filename(__name__, 'cacert.pem')
+    base_dir = txclib.utils.get_base_dir()
+    POSSIBLE_CA_BUNDLE_PATHS = [
+        # Red Hat, CentOS, Fedora and friends
+        # (provided by the ca-certificates package):
+        '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
+        '/etc/ssl/certs/ca-bundle.crt',
+        '/etc/pki/tls/certs/ca-bundle.crt',
+        # Ubuntu, Debian, and friends
+        # (provided by the ca-certificates package):
+        '/etc/ssl/certs/ca-certificates.crt',
+        # FreeBSD (provided by the ca_root_nss package):
+        '/usr/local/share/certs/ca-root-nss.crt',
+        # openSUSE (provided by the ca-certificates package),
+        # the 'certs' directory is the
+        # preferred way but may not be supported by the SSL module,
+        # thus it has 'ca-bundle.pem'
+        # as a fallback (which is generated from pem files in the
+        # 'certs' directory):
+        '/etc/ssl/ca-bundle.pem',
+        # Certificate bundled with library:
+        os.path.join(base_dir, 'txclib', 'cacert.pem'),
+        os.path.join(base_dir, 'cacert.pem'),
+    ]
+    for path in POSSIBLE_CA_BUNDLE_PATHS:
+        if os.path.exists(path):
+            return path
+    return resource_filename(__name__, 'cacert.pem')


### PR DESCRIPTION
`os.path.join(txclib.utils.get_base_dir(), 'txclib', 'cacert.pem')` seemed to point to `site-packages/txclib/txclib/cacert.pem`, which caused a File Not Found error.

While at it, I removed the special-case Windows logic and simply added the bundled PEM to the bottom of the list of locations to search through anyway.

In addition, some needless special-casing of SSLErrors (that made debugging this harder than it should have been :) ) was removed. There are still too many "SSLError" special cases sprinkled around the project for my liking, but at least it works now!