### PR TITLE
Use entry_points instead of scripts for cross-platform compatibility

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,12 +42,11 @@ install:
   - "pip install --disable-pip-version-check --user --upgrade pip"
   - "pip install pyinstaller"
 
-  # Install the build dependencies of the project. If some dependencies contain
+  # Set up the project in develop mode. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  #- "%CMD_IN_ENV% pip install -r dev-requirements.txt"
-  - pip install -r requirements.txt
+  - pip install -e .
 
 build_script:
   # Build the compiled extension

--- a/contrib/test_win_build.sh
+++ b/contrib/test_win_build.sh
@@ -1,4 +1,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BRANCH="win-${PYTHON//C:\\/}"
+
+# Test the PyInstaller executable:
 TX="$DIR/../dist/tx.exe"
 source "$DIR/tx_commands.sh"
+
+# Test the Setuptools script:
+TX="tx"
+source "$DIR/tx_commands.sh"
+

--- a/contrib/tx.spec
+++ b/contrib/tx.spec
@@ -5,7 +5,7 @@ added_files = [
     ('../txclib/cacert.pem', 'txclib'),
 ]
 
-a = Analysis(['../tx'],
+a = Analysis(['../txclib/cmdline.py'],
              binaries=None,
              datas=added_files,
              hiddenimports=[],

--- a/contrib/tx_commands.sh
+++ b/contrib/tx_commands.sh
@@ -1,3 +1,8 @@
+if [[ ! -z "$CI_PULL_REQUEST" ]] ; then
+	echo "NB: Skipping tests of $TX in PR build ($CI_PULL_REQUEST)"
+	exit 0
+fi
+
 # Exit on fail
 set -e
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_file_content(filename):
 setup(
     name="transifex-client",
     version=txclib.__version__,
-    scripts=['tx'],
+    entry_points={'console_scripts': ['tx=txclib.cmdline:main']},
     description="A command line interface for Transifex",
     long_description=get_file_content('README.rst'),
     author="Transifex",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ whitelist_externals = source
                       bash
 install_command = pip install -U {opts} {packages}
 setenv = TOX_ENV_NAME={envname}
-passenv = TOX_* TRANSIFEX_USER TRANSIFEX_PASSWORD
+passenv = TOX_* TRANSIFEX_USER TRANSIFEX_PASSWORD CI_* APPVEYOR_*
 commands = python -V
            python setup.py test
            bash ./contrib/test_build.sh

--- a/txclib/__main__.py
+++ b/txclib/__main__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from .cmdline import main
+
+main()

--- a/txclib/cmdline.py
+++ b/txclib/cmdline.py
@@ -36,10 +36,12 @@ if sys.version_info < (3,0):
     sys.setdefaultencoding('utf-8')
 
 
-def main(argv):
+def main(argv=None):
     """
     Here we parse the flags (short, long) and we instantiate the classes.
     """
+    if argv is None:
+        argv = sys.argv[1:]
     usage = "usage: %prog [options] command [cmd_options]"
     description = "This is the Transifex command line client which"\
 		" allows you to manage your translations locally and sync"\
@@ -110,4 +112,4 @@ def main(argv):
 # Run baby :) ... run
 if __name__ == "__main__":
     # sys.argv[0] is the name of the script that we’re running.
-    main(sys.argv[1:])
+    main()


### PR DESCRIPTION
This makes `tx` work right out of the box when you `pip install transifex-client` on Windows.