### PR TITLE
Handle HTTP exception 401

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch, MagicMock
 from urllib3.exceptions import SSLError
 
-from txclib import utils
+from txclib import utils, exceptions
 
 
 class MakeRequestTestCase(unittest.TestCase):
@@ -87,7 +87,7 @@ class MakeRequestTestCase(unittest.TestCase):
         host = 'http://whynotestsforthisstuff.com'
         url = '/my_test_url/'
         self.assertRaises(
-            utils.HttpNotFound,
+            exceptions.HttpNotFound,
             utils.make_request,
             'GET',
             host,
@@ -110,6 +110,28 @@ class MakeRequestTestCase(unittest.TestCase):
         url = '/my_test_url/'
         self.assertRaises(
             Exception,
+            utils.make_request,
+            'GET',
+            host,
+            url,
+            'a_user',
+            'a_pass'
+        )
+
+    @patch('urllib3.connection_from_url')
+    def test_makes_request_401(self, mock_connection_from_url):
+        response_mock = MagicMock()
+        response_mock.status = 401
+        response_mock.data = 'test_data'
+
+        mock_connection = MagicMock()
+        mock_connection.request.return_value = response_mock
+        mock_connection_from_url.return_value = mock_connection
+
+        host = 'http://whynotestsforthisstuff.com'
+        url = '/my_test_url/'
+        self.assertRaises(
+            exceptions.HttpNotAuthorized,
             utils.make_request,
             'GET',
             host,

--- a/txclib/exceptions.py
+++ b/txclib/exceptions.py
@@ -11,3 +11,14 @@ class UnInitializedError(Exception):
 
 class UnknownCommandError(Exception):
     """The provided command is not supported."""
+
+
+# HTTP exceptions
+
+
+class HttpNotFound(Exception):
+    pass
+
+
+class HttpNotAuthorized(Exception):
+    pass

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -632,6 +632,9 @@ class Project(object):
                     if isinstance(e, SSLError):
                         raise
                     code = getattr(e, 'code', None)
+                    if code == 401:
+                        logger.error("Request is not authorized.")
+                        continue
                     if code == 404:
                         msg = "Resource %s doesn't exist on the server."
                         logger.error(msg % resource)

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -16,14 +16,10 @@ from urllib3.exceptions import SSLError
 from urllib3.packages import six
 from urllib3.packages.six.moves import input
 from txclib.urls import API_URLS
-from txclib.exceptions import UnknownCommandError
+from txclib.exceptions import UnknownCommandError, HttpNotFound, HttpNotAuthorized
 from txclib.paths import posix_path, native_path, posix_sep
 from txclib.web import user_agent_identifier, certs_file
 from txclib.log import logger
-
-
-class HttpNotFound(Exception):
-    pass
 
 
 def get_base_dir():
@@ -135,7 +131,9 @@ def make_request(method, host, url, username, password, fields=None,
             if isinstance(data, bytes):
                 data = data.decode(charset)
         if response.status < 200 or response.status >= 400:
-            if response.status == 404:
+            if response.status == 401:
+                raise HttpNotAuthorized(data)
+            elif response.status == 404:
                 raise HttpNotFound(data)
             else:
                 raise Exception(data)


### PR DESCRIPTION
In some cases Transifex API returns 401 (Not Authorized) which currently raises Exception without providing any extra information for the user. It makes it hard to investigate why push or pull is not happening as expected.

I'm adding a new HTTP exception class + extra logging.