### PR TITLE
test with optional dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-envlist = py27,py35
+envlist = py{27,py35}-{vanilla,pyopenssl}
 
 [testenv]
+deps =
+   pyopenssl: urllib3[secure]
 whitelist_externals = source
                       bash
 install_command = pip install -U {opts} {packages}

--- a/txclib/cmdline.py
+++ b/txclib/cmdline.py
@@ -11,6 +11,14 @@ from txclib import utils
 from txclib.log import set_log_level, logger
 
 
+# use pyOpenSSL if available
+try:
+    import urllib3.contrib.pyopenssl
+    urllib3.contrib.pyopenssl.inject_into_urllib3()
+except ImportError:
+    pass
+
+
 # This block ensures that ^C interrupts are handled quietly.
 try:
     import signal


### PR DESCRIPTION
@dimoschi in order for the SSL warning to go away, as we discussed, this change is necessary in the client.