### PR TITLE
Support for proxies 

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,15 +7,15 @@ from txclib import utils, exceptions
 
 class MakeRequestTestCase(unittest.TestCase):
 
-    @patch('urllib3.connection_from_url')
-    def test_makes_request(self, mock_connection_from_url):
+    @patch('urllib3.PoolManager')
+    def test_makes_request(self, mock_manager):
         response_mock = MagicMock()
         response_mock.status = 200
         response_mock.data = 'test_data'
 
         mock_connection = MagicMock()
         mock_connection.request.return_value = response_mock
-        mock_connection_from_url.return_value = mock_connection
+        mock_manager.return_value = mock_connection
 
         host = 'http://whynotestsforthisstuff.com'
         url = '/my_test_url/'
@@ -26,15 +26,15 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_user',
             'a_pass'
         )
-        mock_connection_from_url.assert_called_once_with(host)
+        mock_manager.assert_called_once_with(host)
         mock_connection.request.assert_called_once()
 
-    @patch('urllib3.connection_from_url')
+    @patch('urllib3.PoolManager')
     @patch('txclib.utils.logger')
-    def test_catches_ssl_error(self, mock_logger, mock_connection_from_url):
+    def test_catches_ssl_error(self, mock_logger, mock_manager):
         mock_connection = MagicMock()
         mock_connection.request.side_effect = SSLError('Boom!')
-        mock_connection_from_url.return_value = mock_connection
+        mock_manager.return_value = mock_connection
 
         host = 'https://whynotestsforthisstuff.com'
         url = '/my_test_url/'
@@ -50,7 +50,7 @@ class MakeRequestTestCase(unittest.TestCase):
         mock_logger.error.assert_called_once_with("Invalid SSL certificate")
 
     @patch('txclib.utils.determine_charset')
-    @patch('urllib3.connection_from_url')
+    @patch('urllib3.PoolManager')
     def test_makes_request_skip_decode(self, mock_conn, mock_determine):
         response_mock = MagicMock()
         response_mock.status = 200
@@ -74,15 +74,15 @@ class MakeRequestTestCase(unittest.TestCase):
         mock_connection.request.assert_called_once()
         mock_determine.assert_not_called()
 
-    @patch('urllib3.connection_from_url')
-    def test_makes_request_404(self, mock_connection_from_url):
+    @patch('urllib3.PoolManager')
+    def test_makes_request_404(self, mock_manager):
         response_mock = MagicMock()
         response_mock.status = 404
         response_mock.data = 'test_data'
 
         mock_connection = MagicMock()
         mock_connection.request.return_value = response_mock
-        mock_connection_from_url.return_value = mock_connection
+        mock_manager.return_value = mock_connection
 
         host = 'http://whynotestsforthisstuff.com'
         url = '/my_test_url/'
@@ -96,15 +96,15 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_pass'
         )
 
-    @patch('urllib3.connection_from_url')
-    def test_makes_request_403(self, mock_connection_from_url):
+    @patch('urllib3.PoolManager')
+    def test_makes_request_403(self, mock_manager):
         response_mock = MagicMock()
         response_mock.status = 403
         response_mock.data = 'test_data'
 
         mock_connection = MagicMock()
         mock_connection.request.return_value = response_mock
-        mock_connection_from_url.return_value = mock_connection
+        mock_manager.return_value = mock_connection
 
         host = 'http://whynotestsforthisstuff.com'
         url = '/my_test_url/'
@@ -118,15 +118,15 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_pass'
         )
 
-    @patch('urllib3.connection_from_url')
-    def test_makes_request_401(self, mock_connection_from_url):
+    @patch('urllib3.PoolManager')
+    def test_makes_request_401(self, mock_manager):
         response_mock = MagicMock()
         response_mock.status = 401
         response_mock.data = 'test_data'
 
         mock_connection = MagicMock()
         mock_connection.request.return_value = response_mock
-        mock_connection_from_url.return_value = mock_connection
+        mock_manager.return_value = mock_connection
 
         host = 'http://whynotestsforthisstuff.com'
         url = '/my_test_url/'
@@ -140,15 +140,15 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_pass'
         )
 
-    @patch('urllib3.connection_from_url')
-    def test_makes_request_None(self, mock_connection_from_url):
+    @patch('urllib3.PoolManager')
+    def test_makes_request_None(self, mock_manager):
         response_mock = MagicMock()
         response_mock.status = 200
         response_mock.data = None
 
         mock_connection = MagicMock()
         mock_connection.request.return_value = response_mock
-        mock_connection_from_url.return_value = mock_connection
+        mock_manager.return_value = mock_connection
 
         host = 'http://whynotestsforthisstuff.com'
         url = '/my_test_url/'
@@ -159,5 +159,5 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_user',
             'a_pass'
         )
-        mock_connection_from_url.assert_called_once_with(host)
+        mock_manager.assert_called_once_with(host)
         mock_connection.request.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_user',
             'a_pass'
         )
-        mock_manager.assert_called_once_with(host)
+        mock_manager.assert_called_once_with(num_pools=1)
         mock_connection.request.assert_called_once()
 
     @patch('urllib3.PoolManager')
@@ -70,7 +70,7 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_pass',
             skip_decode=True
         )
-        mock_conn.assert_called_once_with(host)
+        mock_conn.assert_called_once_with(num_pools=1)
         mock_connection.request.assert_called_once()
         mock_determine.assert_not_called()
 
@@ -159,5 +159,5 @@ class MakeRequestTestCase(unittest.TestCase):
             'a_user',
             'a_pass'
         )
-        mock_manager.assert_called_once_with(host)
+        mock_manager.assert_called_once_with(num_pools=1)
         mock_connection.request.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ whitelist_externals = source
                       bash
 install_command = pip install -U {opts} {packages}
 setenv = TOX_ENV_NAME={envname}
-passenv = TOX_* TRANSIFEX_USER TRANSIFEX_PASSWORD CI CI_* CIRCLECI CIRCLE* APPVEYOR* CODECOV_TOKEN
+passenv = TOX_* TRANSIFEX_USER TRANSIFEX_PASSWORD CI CI_* CIRCLECI CIRCLE* APPVEYOR*
 commands = python -V
            coverage run --append setup.py test
            bash ./contrib/test_build.sh
-           codecov -e TOX_ENV_NAME -t {env:CODECOV_TOKEN:}
+           codecov -e TOX_ENV_NAME

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -26,6 +26,7 @@ from txclib.config import CERT_REQUIRED
 
 def get_base_dir():
     """PyInstaller Run-time Operation.
+
     http://pythonhosted.org/PyInstaller/#run-time-operation
     """
     if getattr(sys, 'frozen', False):
@@ -39,6 +40,7 @@ def get_base_dir():
 
 def find_dot_tx(path=os.path.curdir, previous=None):
     """Return the path where .tx folder is found.
+
     The 'path' should be a DIRECTORY.
     This process is functioning recursively from the current directory to each
     one of the ancestors dirs.
@@ -181,6 +183,7 @@ def make_request(method, host, url, username, password, fields=None,
 def get_details(api_call, username, password, *args, **kwargs):
     """
     Get the tx project info through the API.
+    
     This function can also be used to check the existence of a project.
     """
     url = API_URLS[api_call] % kwargs
@@ -197,6 +200,7 @@ def get_details(api_call, username, password, *args, **kwargs):
 def valid_slug(slug):
     """
     Check if a slug contains only valid characters.
+    
     Valid chars include [-_\w]
     """
     try:
@@ -254,6 +258,7 @@ def mkdir_p(path):
 def confirm(prompt='Continue?', default=True):
     """
     Prompt the user for a Yes/No answer.
+    
     Args:
         prompt: The text displayed to the user ([Y/n] will be appended)
         default: If the default value will be yes or no
@@ -289,6 +294,7 @@ def color_text(text, color_name, bold=False):
     This command can be used to colorify command line output. If the shell
     doesn't support this or the --disable-colors options has been set, it just
     returns the plain text.
+    
     Usage:
         print "%s" % color_text("This text is red", "RED")
     """
@@ -302,6 +308,7 @@ def color_text(text, color_name, bold=False):
 def files_in_project(curpath):
     """
     Iterate over the files in the project.
+    
     Return each file under ``curpath`` with its absolute name.
     """
     visited = set()

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -26,7 +26,6 @@ from txclib.config import CERT_REQUIRED
 
 def get_base_dir():
     """PyInstaller Run-time Operation.
-
     http://pythonhosted.org/PyInstaller/#run-time-operation
     """
     if getattr(sys, 'frozen', False):
@@ -40,7 +39,6 @@ def get_base_dir():
 
 def find_dot_tx(path=os.path.curdir, previous=None):
     """Return the path where .tx folder is found.
-
     The 'path' should be a DIRECTORY.
     This process is functioning recursively from the current directory to each
     one of the ancestors dirs.
@@ -106,36 +104,42 @@ def determine_charset(response):
 
 def make_request(method, host, url, username, password, fields=None,
                  skip_decode=False):
-    
+
     # Initialize http and https pool managers
     num_pools = 1
     managers = {}
-    if "http_proxy" in os.environ:
-        proxy_url = os.environ["http_proxy"]
-        managers["http"] = urllib3.ProxyManager(
-            proxy_url=proxy_url,
-            proxy_headers={"User-Agent": user_agent_identifier()},
-            num_pools=num_pools
-        )
-    else:
-        managers["http"] = urllib3.PoolManager(num_pools=num_pools)
 
-    if "https_proxy" in os.environ:
-        proxy_url = os.environ["https_proxy"]
-        managers["https"] = urllib3.ProxyManager(
-            proxy_url=proxy_url,
-            proxy_headers={"User-Agent": user_agent_identifier()},
-            num_pools=num_pools,
-            cert_reqs=CERT_REQUIRED,
-            ca_certs=certs_file()
-        )
+    if host.lower().startswith("http://"):
+        scheme = "http"
+        if "http_proxy" in os.environ:
+            proxy_url = os.environ["http_proxy"]
+            managers["http"] = urllib3.ProxyManager(
+                proxy_url=proxy_url,
+                proxy_headers={"User-Agent": user_agent_identifier()},
+                num_pools=num_pools
+            )
+        else:
+            managers["http"] = urllib3.PoolManager(num_pools=num_pools)
+    elif host.lower().startswith("https://"):
+        scheme = "https"
+        if "https_proxy" in os.environ:
+            proxy_url = os.environ["https_proxy"]
+            managers["https"] = urllib3.ProxyManager(
+                proxy_url=proxy_url,
+                proxy_headers={"User-Agent": user_agent_identifier()},
+                num_pools=num_pools,
+                cert_reqs=CERT_REQUIRED,
+                ca_certs=certs_file()
+            )
+        else:
+            managers["https"] = urllib3.PoolManager(
+                num_pools=num_pools,
+                cert_reqs=CERT_REQUIRED,
+                ca_certs=certs_file()
+            )
     else:
-        managers["https"] = urllib3.PoolManager(
-            num_pools=num_pools,
-            cert_reqs=CERT_REQUIRED,
-            ca_certs=certs_file()
-        )
-    
+        raise Exception("Unknown scheme")
+
     charset = None
     headers = urllib3.util.make_headers(
         basic_auth='{0}:{1}'.format(username, password),
@@ -143,15 +147,9 @@ def make_request(method, host, url, username, password, fields=None,
         user_agent=user_agent_identifier(),
         keep_alive=True
     )
-    
+
     response = None
     try:
-        if host.lower().startswith("http://"):
-            scheme = "http"
-        elif host.lower().startswith("https://"):
-            scheme = "https"
-        else:
-            raise Exception("Unknown scheme")
         manager = managers[scheme]
         response = manager.request(
             method,
@@ -183,7 +181,6 @@ def make_request(method, host, url, username, password, fields=None,
 def get_details(api_call, username, password, *args, **kwargs):
     """
     Get the tx project info through the API.
-
     This function can also be used to check the existence of a project.
     """
     url = API_URLS[api_call] % kwargs
@@ -200,7 +197,6 @@ def get_details(api_call, username, password, *args, **kwargs):
 def valid_slug(slug):
     """
     Check if a slug contains only valid characters.
-
     Valid chars include [-_\w]
     """
     try:
@@ -258,7 +254,6 @@ def mkdir_p(path):
 def confirm(prompt='Continue?', default=True):
     """
     Prompt the user for a Yes/No answer.
-
     Args:
         prompt: The text displayed to the user ([Y/n] will be appended)
         default: If the default value will be yes or no
@@ -294,7 +289,6 @@ def color_text(text, color_name, bold=False):
     This command can be used to colorify command line output. If the shell
     doesn't support this or the --disable-colors options has been set, it just
     returns the plain text.
-
     Usage:
         print "%s" % color_text("This text is red", "RED")
     """
@@ -308,7 +302,6 @@ def color_text(text, color_name, bold=False):
 def files_in_project(curpath):
     """
     Iterate over the files in the project.
-
     Return each file under ``curpath`` with its absolute name.
     """
     visited = set()

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -6,13 +6,7 @@ import errno
 import urllib3
 import collections
 import six
-import urllib3
 import ssl
-
-if sys.version_info[0] >= 3:
-    from urllib.request import Request
-else:
-    from urllib2 import Request
 
 try:
     from json import loads as parse_json, dumps as compile_json
@@ -112,6 +106,7 @@ def determine_charset(response):
 
 def make_request(method, host, url, username, password, fields=None,
                  skip_decode=False):
+    
     # Initialize http and https pool managers
     num_pools = 1
     managers = {}
@@ -131,13 +126,13 @@ def make_request(method, host, url, username, password, fields=None,
             proxy_url=proxy_url,
             proxy_headers={"User-Agent": user_agent_identifier()},
             num_pools=num_pools,
-            cert_reqs=ssl.CERT_REQUIRED,
+            cert_reqs=CERT_REQUIRED,
             ca_certs=certs_file()
         )
     else:
         managers["https"] = urllib3.PoolManager(
             num_pools=num_pools,
-            cert_reqs=ssl.CERT_REQUIRED,
+            cert_reqs=CERT_REQUIRED,
             ca_certs=certs_file()
         )
     
@@ -148,21 +143,20 @@ def make_request(method, host, url, username, password, fields=None,
         user_agent=user_agent_identifier(),
         keep_alive=True
     )
-    request = Request(host + url, None, headers)
-    request.type = method
+    
     response = None
     try:
-        if host.startswith("http://"):
+        if host.lower().startswith("http://"):
             scheme = "http"
-        elif host.startswith("https://"):
+        elif host.lower().startswith("https://"):
             scheme = "https"
         else:
             raise Exception("Unknown scheme")
         manager = managers[scheme]
         response = manager.request(
             method,
-            request.get_full_url(),
-            headers=dict(request.header_items()),
+            host + url,
+            headers=dict(headers),
             fields=fields
         )
         data = response.data


### PR DESCRIPTION
A working version of the Transifex client with added support for proxies. To use, set the http_proxy and https_proxy environment variables. @kouk 