### PR TITLE
Remove token, not used in public repos

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ whitelist_externals = source
                       bash
 install_command = pip install -U {opts} {packages}
 setenv = TOX_ENV_NAME={envname}
-passenv = TOX_* TRANSIFEX_USER TRANSIFEX_PASSWORD CI CI_* CIRCLECI CIRCLE* APPVEYOR* CODECOV_TOKEN
+passenv = TOX_* TRANSIFEX_USER TRANSIFEX_PASSWORD CI CI_* CIRCLECI CIRCLE* APPVEYOR*
 commands = python -V
            coverage run --append setup.py test
            bash ./contrib/test_build.sh
-           codecov -e TOX_ENV_NAME -t {env:CODECOV_TOKEN:}
+           codecov -e TOX_ENV_NAME


### PR DESCRIPTION
@tabac & @kouk codecov token is not needed, because client is public repo. Also it prevents forked branches to be merged.