### PR TITLE
Fix UnicodeDecodeError for httplib

### DIFF
--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -111,6 +111,11 @@ def make_request(method, host, url, username, password, fields=None,
     num_pools = 1
     managers = {}
 
+    if isinstance(host, unicode):
+        host = host.encode('UTF-8')
+    if isinstance(url, unicode):
+        url = url.encode('UTF-8')
+
     if host.lower().startswith("http://"):
         scheme = "http"
         if "http_proxy" in os.environ:


### PR DESCRIPTION
Python 2.7.6 - /usr/lib/python2.7/httplib.py has the following code:
```python
 820 def _send_output(self, message_body=None):
 821         Send the currently buffered request and clear the buffer. -----
 826         self._buffer.extend(("", ""))
 827         msg = "\r\n".join(self._buffer)
 828         del self._buffer[:]
 829         # If msg and message_body are sent in a single send() call,
 830         # it will avoid performance problems caused by the interaction
 831         # between delayed ack and the Nagle algorithm.
 832         if isinstance(message_body, str):
 833             msg += message_body
 834             message_body = None
 835         self.send(msg)
```

If the variable `self._buffer` (line 827) has
[u'PUT /api/2/project/PROJECT/resource/RESOURCE/content/ HTTP/1.1', ...]
then `msg` variable is unicode string
but `message_body` is bytes string (line 832)
The line 833 concatenate unicode + bytes string and show the error:
`Fix UnicodeDecodeError: 'ascii' codec can't decode byte ... in position ...: ordinal not in range(128)`

It's fixed forcing in `host` and `url` variables of transifex-client use bytes to concatenate bytes vs bytes.