### PR TITLE
Add the packaging metadata to build the tx snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: tx
+version: master
+summary: The Transifex command-line tool
+description: |
+  The Transifex Command-line Tool enables you to manage your translations
+  within a project without the need of an elaborate UI system.
+
+  You can use the command line tool to create new resources, map locale files
+  to translations, and synchronize your Transifex project with your local
+  repository. Translators and localization managers can use it to handle large
+  volumes of translation files. The Transifex Command-line Tool can help to
+  enable continuous integration workflows and can be run from CI servers like Jenkins and Bamboo.
+
+grade: devel
+confinement: strict
+
+apps:
+  tx:
+    command: tx
+    plugs: [network, home]
+
+parts:
+  transifex-client:
+    source: .
+    plugin: python


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.
