### PR TITLE
Use xliff parameter when getting resource files on push

### DIFF
--- a/txclib/project.py
+++ b/txclib/project.py
@@ -659,7 +659,7 @@ class Project(object):
         for resource in resource_list:
             push_languages = []
             project_slug, resource_slug = resource.split('.', 1)
-            files = self.get_resource_files(resource, xliff=True)
+            files = self.get_resource_files(resource, xliff=xliff)
             slang = self.get_resource_option(resource, 'source_lang')
             sfile = self.get_source_file(resource)
             lang_map = self.get_resource_lang_mapping(resource)


### PR DESCRIPTION
This commit https://github.com/transifex/transifex-client/commit/1eae96b4409fd248207e879abda4e1703610a992 broke pushing of .po files as it blindly sets xliff to `True` instead of reading the parameter sent to the function.

If you try to push a .po file with with the current client you will stumble upon the error message:
`Skipping '<LANG>' translation (file: <PATH><FILE>.po.xlf).` even if you have not set the -x/--xliff flag in your push command.