### PR TITLE
Don't break if on translation push a file is not available locally

### DIFF
--- a/contrib/tx_commands.sh
+++ b/contrib/tx_commands.sh
@@ -18,11 +18,11 @@ $TX set --auto-local -r txci.$BRANCH\_$TRANSIFEX_USER\_$RANDOM -s en 'locale/<la
 echo "Pushing Source..."
 $TX --traceback push -s
 echo "Pushing Brazilian..."
-yes | $TX --traceback push -t -l pt_BR -f
-yes | $TX --traceback pull -l pt_BR -f
+$TX --traceback push -t -l pt_BR -f --no-interactive
+$TX --traceback pull -l pt_BR -f
 
 echo "Pushing a file that doesn't exist..."
-yes | $TX --traceback push -t -l pt_PT -f
+$TX --traceback push -t -l pt_PT -f --no-interactive
 
 # try to download translation xliff
 echo "Pulling xliff for pt_BR"
@@ -32,7 +32,7 @@ ls locale/pt_BR/LC_MESSAGES/django.po.xlf
 
 # upload xliff
 echo "Pushing xliff for pt_BR"
-$TX --traceback push -t -l pt_BR --xliff
+$TX --traceback push -t -l pt_BR --xliff -f --no-interactive
 
 
 $TX --traceback delete -f

--- a/contrib/tx_commands.sh
+++ b/contrib/tx_commands.sh
@@ -21,6 +21,9 @@ echo "Pushing Brazilian..."
 yes | $TX --traceback push -t -l pt_BR -f
 yes | $TX --traceback pull -l pt_BR -f
 
+echo "Pushing a file that doesn't exist..."
+yes | $TX --traceback push -t -l pt_PT -f
+
 # try to download translation xliff
 echo "Pulling xliff for pt_BR"
 $TX --traceback pull -l pt_BR --xliff

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -754,15 +754,11 @@ class Project(object):
                     push_languages = list(files.keys())
                 else:
                     push_languages = []
-                    f_langs = list(files.keys())
                     for l in languages:
                         if l in list(lang_map.keys()):
                             l = lang_map[l]
                         push_languages.append(l)
-                        if l not in f_langs:
-                            msg = "Warning: No mapping found for "
-                            "language code '%s'."
-                            logger.error(msg % utils.color_text(l, "RED"))
+
                 logger.debug("Languages to push are %s" % push_languages)
 
                 # Push translation files one by one
@@ -773,7 +769,12 @@ class Project(object):
                     else:
                         remote_lang = lang
 
-                    local_file = files[local_lang]
+                    local_file = files.get(local_lang)
+                    if not local_file:
+                        msg = ("Warning: No local translation file found for "
+                               "language code '%s'.")
+                        logger.error(msg % utils.color_text(lang, "RED"))
+                        continue
 
                     kwargs = {
                         'lang': remote_lang,


### PR DESCRIPTION
While trying to push translations to Transifex for a set of resources, if one of the resources didn't have a translation file yet in the repo/locally, the push out abort with an exception.