### PR TITLE
[FIX] raise HttpNotAuthorized for 403 errors

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -109,7 +109,7 @@ class MakeRequestTestCase(unittest.TestCase):
         host = 'http://whynotestsforthisstuff.com'
         url = '/my_test_url/'
         self.assertRaises(
-            Exception,
+            exceptions.HttpNotAuthorized,
             utils.make_request,
             'GET',
             host,

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -173,7 +173,7 @@ def make_request(method, host, url, username, password, fields=None,
             if isinstance(data, bytes):
                 data = data.decode(charset)
         if response.status < 200 or response.status >= 400:
-            if response.status == 401:
+            if response.status in (401, 403):
                 raise HttpNotAuthorized(data)
             elif response.status == 404:
                 raise HttpNotFound(data)


### PR DESCRIPTION
If a user does not belong to the translation team and tries to make a tx pull,
a 403 status code is returned.

Instead of just displaying "Exception", gives a bit more context on the failure