### PR TITLE
TX-8362 Return non-zero exit code on errors

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,20 @@
+import unittest
+from txclib.commands import _set_source_file, _set_translation, cmd_pull, \
+    UnInitializedError
+
+
+class TestCommands(unittest.TestCase):
+    def test_cmd_pull_return_exception_when_dir_not_initialized(self):
+        """Test when tx is not instantiated, that proper error is thrown"""
+        with self.assertRaises(UnInitializedError):
+            cmd_pull([], None)
+
+    def test_set_source_file_when_dir_not_initialized(self):
+        with self.assertRaises(UnInitializedError):
+            _set_source_file(path_to_tx=None, resource='dummy_resource.en',
+                             lang='en', path_to_file='dummy')
+
+    def test_set_translation_when_dir_not_initialized(self):
+        with self.assertRaises(UnInitializedError):
+            _set_translation(path_to_tx=None, resource="dummy_resource.md",
+                             lang='en', path_to_file='invalid')

--- a/txclib/cmdline.py
+++ b/txclib/cmdline.py
@@ -113,10 +113,9 @@ def main(argv=None):
         logger.error("SSl error %s" % e)
         sys.exit(1)
     except utils.UnknownCommandError:
-        logger.error("tx: Command %s not found" % cmd)
-    except SystemExit:
-        sys.exit()
-    except:
+        logger.error("Command %s not found" % cmd)
+        sys.exit(1)
+    except Exception:
         import traceback
         if options.trace:
             traceback.print_exc()

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -172,11 +172,7 @@ def cmd_set(argv, path_to_tx):
         # Calculate relative path
         path_to_file = os.path.relpath(args[0], path_to_tx)
 
-        try:
-            _go_to_dir(path_to_tx)
-        except UnInitializedError as e:
-            utils.logger.error(e)
-            return
+        _go_to_dir(path_to_tx)
 
         if not utils.valid_slug(resource):
             parser.error("Invalid resource slug. The format is <project_slug>"
@@ -368,11 +364,7 @@ def cmd_pull(argv, path_to_tx):
     skip = options.skip_errors
     minimum_perc = options.minimum_perc or None
 
-    try:
-        _go_to_dir(path_to_tx)
-    except UnInitializedError as e:
-        utils.logger.error(e)
-        return
+    _go_to_dir(path_to_tx)
 
     # instantiate the project.Project
     prj = project.Project(path_to_tx)
@@ -396,11 +388,7 @@ def _set_source_file(path_to_tx, resource, lang, path_to_file):
     if not lang:
         raise Exception("You haven't specified a source language.")
 
-    try:
-        _go_to_dir(path_to_tx)
-    except UnInitializedError as e:
-        utils.logger.error(e)
-        return
+    _go_to_dir(path_to_tx)
 
     if not os.path.exists(path_to_file):
         raise Exception("tx: File ( %s ) does not exist." %
@@ -447,11 +435,7 @@ def _set_translation(path_to_tx, resource, lang, path_to_file):
                         "project_slug.resource_slug." %
                         resource)
 
-    try:
-        _go_to_dir(path_to_tx)
-    except UnInitializedError as e:
-        utils.logger.error(e)
-        return
+    _go_to_dir(path_to_tx)
 
     # Warn the user if the file doesn't exist
     if not os.path.exists(path_to_file):
@@ -563,7 +547,7 @@ def _go_to_dir(path):
     """
     if path is None:
         raise UnInitializedError(
-            "Directory has not been initialzied. "
+            "Directory has not been initialized. "
             "Did you forget to run 'tx init' first?"
         )
     os.chdir(path)

--- a/txclib/log.py
+++ b/txclib/log.py
@@ -13,7 +13,7 @@ _logger.setLevel(logging.CRITICAL)
 _logger = logging.getLogger('txclib')
 _logger.setLevel(logging.INFO)
 
-_formatter = logging.Formatter('%(message)s')
+_formatter = logging.Formatter('tx %(levelname)s: %(message)s')
 
 _error_handler = logging.StreamHandler(sys.stderr)
 _error_handler.setLevel(logging.ERROR)

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -1318,8 +1318,8 @@ class Project(object):
             res = utils.parse_json(json)
             return res[i18n_type]['file-extensions'].split(',')[0]
         except Exception as e:
-            logger.error(
-                "WARNING: The file extension for i18n_type %s is not found."
+            logger.warning(
+                "The file extension for i18n_type %s is not found."
                 % e.message)
             return ''
 
@@ -1394,7 +1394,7 @@ class Project(object):
             try:
                 url = PULL_MODE_URL_MAPPING[mode]
             except KeyError:
-                logger.warning('WARNING: invalid mode provided. ' +
+                logger.warning('Invalid mode provided. ' +
                                'Default pull mode will be used')
 
         return DEFAULT_PULL_URL if url is None else url


### PR DESCRIPTION
Throw error in the following cases:
- when user calls tx pull and the project is not initialized
- When the given command is not found an 1 error code will be returned
Also, add error level information on logger output.

Related issue #186 