### PR TITLE
Create new Set subcommand for multiple files and auto-local, auto-remote

### DIFF
--- a/contrib/tx_commands.sh
+++ b/contrib/tx_commands.sh
@@ -12,7 +12,7 @@ git clone https://github.com/transifex/txci.git
 cd txci
 rm -rf .tx
 $TX init --host="https://www.transifex.com" --token=$TRANSIFEX_TOKEN --skipsetup --no-interactive
-$TX set --auto-local -r txci.$BRANCH\_$TRANSIFEX_USER\_$RANDOM -s en 'locale/<lang>/LC_MESSAGES/django.po' -t PO --execute
+$TX set auto-local -r txci.$BRANCH\_$TRANSIFEX_USER\_$RANDOM -s en 'locale/<lang>/LC_MESSAGES/django.po' -t PO --execute
 
 # push/pull without XLIFF
 echo "Pushing Source..."

--- a/tests/project_dir/.transifexrc
+++ b/tests/project_dir/.transifexrc
@@ -1,0 +1,6 @@
+[https://www.transifex.com]
+api_hostname = https://api.transifex.com
+hostname = https://www.transifex.com
+password = foo
+username = bar
+

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -267,7 +267,8 @@ class TestSetCommand(unittest.TestCase):
             cmd_set(args, self.path_to_tx)
 
     @patch('txclib.utils.get_details')
-    def test_auto_remote_project(self, get_details_mock):
+    @patch('txclib.project.Project._extension_for')
+    def test_auto_remote_project(self, extension_mock, get_details_mock):
         # change the host to tx
         open(self.config_file, "w").write(
             '[main]\nhost = https://www.transifex.com\n'
@@ -278,6 +279,7 @@ class TestSetCommand(unittest.TestCase):
                     "source_lang = fr\ntype = TXT\n\n[proj.resource_2]\n"
                     "file_filter = translations/proj.resource_2/<lang>.txt\n"
                     "source_lang = fr\ntype = TXT\n\n")
+        extension_mock.return_value = ".txt"
         get_details_mock.side_effect = [
             # project details
             {

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,7 +5,8 @@ import sys
 from StringIO import StringIO
 from mock import patch, MagicMock, call
 from txclib.commands import _set_source_file, _set_translation, cmd_pull, \
-    cmd_init, cmd_status, cmd_help, UnInitializedError
+    cmd_init, cmd_set, cmd_status, cmd_help, UnInitializedError
+from txclib.cmdline import main
 
 
 class TestCommands(unittest.TestCase):
@@ -64,6 +65,7 @@ class TestInitCommand(unittest.TestCase):
 
     def setUp(self):
         self.curr_dir = os.getcwd()
+        self.config_file = '.tx/config'
         os.chdir('./tests/project_dir/')
 
     def tearDown(self, *args, **kwargs):
@@ -81,7 +83,7 @@ class TestInitCommand(unittest.TestCase):
                 set_mock.assert_called_once_with([], os.getcwd())
         self.assertTrue(os.path.exists('./.tx'))
         self.assertTrue(os.path.exists('./.tx/config'))
-        self.assertEqual(open('.tx/config').read(), config_text)
+        self.assertEqual(open(self.config_file).read(), config_text)
 
     def test_init_skipsetup(self):
         argv = ['--skipsetup']
@@ -172,8 +174,169 @@ class TestPullCommand(unittest.TestCase):
         bmock.return_value = None
         cmd_pull(['--branch', '--branchname', 'somebranch'], '.')
         assert pr_instance.pull.call_count == 1
-        pull_call = call(branch='somebranch', fetchall=False, fetchsource=False,
-                         force=False, languages=[], minimum_perc=None, mode=None,
-                         overwrite=True, pseudo=False, resources=[], skip=False,
-                         xliff=False)
+        pull_call = call(
+            branch='somebranch', fetchall=False, fetchsource=False,
+            force=False, languages=[], minimum_perc=None, mode=None,
+            overwrite=True, pseudo=False, resources=[], skip=False, xliff=False
+        )
         pr_instance.pull.assert_has_calls([pull_call])
+
+
+class TestSetCommand(unittest.TestCase):
+
+    def setUp(self):
+        self.curr_dir = os.getcwd()
+        os.chdir('./tests/project_dir/')
+        os.mkdir('.tx')
+        self.path_to_tx = os.getcwd()
+        self.config_file = '.tx/config'
+        open(self.config_file, "w").write('[main]\nhost = https://foo.var\n')
+
+    def tearDown(self, *args, **kwargs):
+        shutil.rmtree('.tx', ignore_errors=False, onerror=None)
+        os.chdir(self.curr_dir)
+        super(TestSetCommand, self).tearDown(*args, **kwargs)
+
+    def test_bare_set_too_few_arguments(self):
+        with self.assertRaises(SystemExit):
+            args = ["-r", "project1.resource1"]
+            cmd_set(args, None)
+
+    def test_bare_set_source_no_file(self):
+        with self.assertRaises(SystemExit):
+            args = ["-r", "project1.resource1", '--is-source', '-l', 'en']
+            cmd_set(args, None)
+
+        with self.assertRaises(Exception):
+            args = ['-r', 'project1.resource1', '--source', '-l', 'en',
+                    'noexistent-file.txt']
+            cmd_set(args, self.path_to_tx)
+
+    def test_bare_set_source_file(self):
+        expected = ("[main]\nhost = https://foo.var\n\n[project1.resource1]\n"
+                    "source_file = test.txt\nsource_lang = en\n\n")
+        args = ["-r", "project1.resource1", '--source', '-l', 'en', 'test.txt']
+        cmd_set(args, self.path_to_tx)
+        with open(self.config_file) as config:
+            self.assertEqual(config.read(), expected)
+
+        # set translation file for de
+        expected = ("[main]\nhost = https://foo.var\n\n[project1.resource1]\n"
+                    "source_file = test.txt\nsource_lang = en\n"
+                    "trans.de = translations/de.txt\n\n")
+        args = ["-r", "project1.resource1", '-l', 'de', 'translations/de.txt']
+        cmd_set(args, self.path_to_tx)
+        with open(self.config_file) as config:
+            self.assertEqual(config.read(), expected)
+
+    def test_auto_locale_no_expression(self):
+        with self.assertRaises(SystemExit):
+            args = ["auto-local", "-r", "project1.resource1",
+                    '--source-language', 'en']
+            cmd_set(args, self.path_to_tx)
+
+    def test_auto_locale(self):
+        expected = "[main]\nhost = https://foo.var\n"
+        args = ["auto-local", "-r", "project1.resource1", '--source-language',
+                'en', 'translations/<lang>/test.txt']
+        cmd_set(args, self.path_to_tx)
+        with open(self.config_file) as config:
+            self.assertEqual(config.read(), expected)
+
+    def test_auto_locale_execute(self):
+        expected = ("[main]\nhost = https://foo.var\n\n[project1.resource1]\n"
+                    "file_filter = translations/<lang>/test.txt\n"
+                    "source_file = translations/en/test.txt\n"
+                    "source_lang = en\n\n")
+
+        args = ["auto-local", "-r", "project1.resource1", '--source-language',
+                'en', '--execute', 'translations/<lang>/test.txt']
+        cmd_set(args, self.path_to_tx)
+        with open(self.config_file) as config:
+            self.assertEqual(config.read(), expected)
+
+    def test_auto_remote_invalid_url(self):
+        # no project_url
+        args = ["auto-remote"]
+        with self.assertRaises(SystemExit):
+            cmd_set(args, self.path_to_tx)
+
+        # invalid project_url
+        args = ["auto-remote", "http://some.random.url/"]
+        with self.assertRaises(Exception):
+            cmd_set(args, self.path_to_tx)
+
+    @patch('txclib.utils.get_details')
+    def test_auto_remote_project(self, get_details_mock):
+        # change the host to tx
+        open(self.config_file, "w").write(
+            '[main]\nhost = https://www.transifex.com\n'
+        )
+        expected = ("[main]\nhost = https://www.transifex.com\n\n"
+                    "[proj.resource_1]\n"
+                    "file_filter = translations/proj.resource_1/<lang>.txt\n"
+                    "source_lang = fr\ntype = TXT\n\n[proj.resource_2]\n"
+                    "file_filter = translations/proj.resource_2/<lang>.txt\n"
+                    "source_lang = fr\ntype = TXT\n\n")
+        get_details_mock.side_effect = [
+            # project details
+            {
+                'resources': [
+                    {'slug': 'resource_1', 'name': 'resource 1'},
+                    {'slug': 'resource_2', 'name': 'resource 2'}
+                ]
+            },
+            # resources details
+            {
+                'source_language_code': 'fr',
+                'i18n_type': 'TXT',
+                'slug': 'resource_1',
+            }, {
+                'source_language_code': 'fr',
+                'i18n_type': 'TXT',
+                'slug': 'resource_2',
+            }
+        ]
+        args = ["auto-remote", "https://www.transifex.com/test-org/proj/"]
+        cmd_set(args, self.path_to_tx)
+        with open(self.config_file) as config:
+            self.assertEqual(config.read(), expected)
+
+    def test_bulk_missing_options(self):
+        with self.assertRaises(SystemExit):
+            args = ["bulk"]
+            cmd_set(args, self.path_to_tx)
+
+        with self.assertRaises(SystemExit):
+            args = ["bulk", "-p", "test-project"]
+            cmd_set(args, self.path_to_tx)
+
+        with self.assertRaises(SystemExit):
+            args = ["bulk", "-p", "test-project", "--source-file-dir",
+                    "translations", "--source-language", "en", "--t", "TXT",
+                    "--file-extension", ".txt"]
+            cmd_set(args, self.path_to_tx)
+
+    def test_bulk(self):
+        expected = ("[main]\nhost = https://foo.var\n\n"
+                    "[test-project.translations_en_test]\n"
+                    "file_filter = translations/<lang>/en/test.txt\n"
+                    "source_file = translations/en/test.txt\n"
+                    "source_lang = en\ntype = TXT\n\n")
+        args = ["bulk", "-p", "test-project", "--source-file-dir",
+                "translations", "--source-language", "en", "-t", "TXT",
+                "--file-extension", ".txt", "--execute",
+                "translations/<lang>/{filepath}/{filename}{extension}"]
+        cmd_set(args, self.path_to_tx)
+        with open(self.config_file) as config:
+            self.assertEqual(config.read(), expected)
+
+
+class TestMainCommand(unittest.TestCase):
+    def test_call_tx_with_no_command(self):
+        with self.assertRaises(SystemExit):
+            main(['tx'])
+
+    def test_call_tx_with_invalid_command(self):
+        with self.assertRaises(SystemExit):
+            main(['tx', 'random'])

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -137,7 +137,6 @@ class WizardCase(unittest.TestCase):
             options = self.wizard.run()
 
             expected_options = {
-                'execute': True,
                 'source_file': 'test_file',
                 'expression': 'translations/<lang>.txt',
                 'i18n_type': 'INI',

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -137,6 +137,7 @@ class WizardCase(unittest.TestCase):
             options = self.wizard.run()
 
             expected_options = {
+                'execute': True,
                 'source_file': 'test_file',
                 'expression': 'translations/<lang>.txt',
                 'i18n_type': 'INI',

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -121,6 +121,7 @@ def cmd_set(argv, path_to_tx):
             )
         except KeyError:
             parser.print_help()
+            sys.exit(2)
 
 
 def _validate_set_arguments(parser, options):

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -91,15 +91,22 @@ def cmd_set(argv, path_to_tx):
     """Add local or remote files under transifex"""
     from_wizard = False
     if len(argv) == 0:
-        # Run the wizard and configure parse with the wizard inputs
+        # since interactive wizard should be equivalant to auto-local
+        # subcommand there are some default options that need to be set
+        default_options = {
+            'execute': True,
+            'subcommand': 'auto-local',
+            'minimum_perc': 0,
+            'mode': None,
+        }
         try:
+            # Run the wizard and configure parse with the wizard inputs
             wizard_options = Wizard(path_to_tx).run()
-            wizard_options['subcommand'] = 'auto-local'
-            wizard_options['minimum_perc'] = 0
-            is_subcommand = True
+            wizard_options.update(default_options)
             options = Namespace(**wizard_options)
             parser = set_parser()
             from_wizard = True
+            is_subcommand = True
         except SystemExit:
             print("\n")
             sys.exit(1)

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -106,14 +106,11 @@ def cmd_set(argv, path_to_tx):
             options = Namespace(**wizard_options)
             parser = set_parser()
             from_wizard = True
-            is_subcommand = True
         except SystemExit:
             print("\n")
             sys.exit(1)
     else:
-        is_subcommand = False
-        if len(argv) >= 1 and argv[0] in SET_SUBCOMMANDS.keys():
-            is_subcommand = True
+        is_subcommand = argv[0] in SET_SUBCOMMANDS.keys()
         parser = set_parser(subparser=is_subcommand)
         options = parser.parse_args(argv)
 

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -21,6 +21,7 @@ try:
     import configparser
 except ImportError:
     import ConfigParser as configparser
+from argparse import Namespace
 
 from txclib import utils, project
 from txclib.config import OrderedRawConfigParser
@@ -36,13 +37,8 @@ from txclib import messages
 def cmd_init(argv, path_to_tx):
     """Initialize a new transifex project."""
     parser = init_parser()
-    (options, args) = parser.parse_args(argv)
-    if len(args) > 1:
-        parser.error("Too many arguments were provided. Aborting...")
-    if args:
-        path_to_tx = args[0]
-    else:
-        path_to_tx = os.getcwd()
+    options = parser.parse_args(argv)
+    path_to_tx = options.path_to_tx or os.getcwd()
 
     print(messages.init_intro)
     save = options.save
@@ -93,104 +89,64 @@ def cmd_init(argv, path_to_tx):
 
 def cmd_set(argv, path_to_tx):
     """Add local or remote files under transifex"""
-    parser = set_parser()
-    wizard_run = False
+    from_wizard = False
     if len(argv) == 0:
         # Run the wizard and configure parse with the wizard inputs
         try:
             wizard_options = Wizard(path_to_tx).run()
-            wizard_run = True
+            wizard_options['subcommand'] = 'auto-local'
+            subcommand = True
+            options = Namespace(**wizard_options)
+            from_wizard = True
         except SystemExit:
             print("\n")
             sys.exit(1)
-
-        options, args = set_parser().parse_args([])
-        args.append(wizard_options.get('expression'))
-        options.source_file = wizard_options.get('source_file')
-        options.source_language = wizard_options.get('source_language')
-        options.i18n_type = wizard_options.get('i18n_type')
-        options.resource = wizard_options.get('resource')
-        options.local = True
-        options.execute = True
     else:
-        options, args = parser.parse_args(argv)
-
-    if options.local:
-        try:
-            expression = args[0]
-        except IndexError:
-            parser.error("Please specify an expression.")
-        if not options.resource:
-            parser.error("Please specify a resource")
-        if not options.source_language:
-            parser.error("Please specify a source language.")
-        if '<lang>' not in expression:
-            parser.error("The expression you have provided is not valid.")
-        if not utils.valid_slug(options.resource):
-            parser.error("Invalid resource slug. The format is <project_slug>"
-                         ".<resource_slug> and the valid characters include"
-                         " [_-\w].")
-        _auto_local(path_to_tx, options.resource,
-                    source_language=options.source_language,
-                    expression=expression, source_file=options.source_file,
-                    execute=options.execute, regex=False)
-        if options.execute:
-            _set_minimum_perc(options.resource, options.minimum_perc,
-                              path_to_tx)
-            _set_mode(options.resource, options.mode, path_to_tx)
-            _set_type(options.resource, options.i18n_type, path_to_tx)
-            if wizard_run:
-                _print_instructions(options.resource, path_to_tx)
-        return
-
-    if options.remote:
-        try:
-            url = args[0]
-        except IndexError:
-            parser.error("Please specify a remote url")
-        _auto_remote(path_to_tx, url)
-        _set_minimum_perc(options.resource, options.minimum_perc, path_to_tx)
-        _set_mode(options.resource, options.mode, path_to_tx)
-        return
+        subcommand = False
+        if len(argv) >= 1 and argv[0] in ['auto-local', 'auto-remote', 'bulk']:
+            subcommand = True
+        parser = set_parser(subparser=subcommand)
+        options = parser.parse_args()
 
     if options.is_source:
-        resource = options.resource
-        if not resource:
+        if not options.resource:
             parser.error("You must specify a resource name with the "
                          "-r|--resource flag.")
 
-        lang = options.language
-        if not lang:
+        if not options.language:
             parser.error("Please specify a source language.")
 
-        if len(args) != 1:
-            parser.error("Please specify a file.")
+        if options.expression and '<lang>' not in options.expression:
+            parser.error("The expression you have provided is not valid.")
 
-        if not utils.valid_slug(resource):
-            parser.error("Invalid resource slug. The format is <project_slug>"
-                         ".<resource_slug> and the valid characters include "
-                         "[_-\w].")
+    if not utils.valid_slug(options.resource):
+        parser.error("Invalid resource slug. The format is <project_slug>"
+                     ".<resource_slug> and the valid characters include "
+                     "[_-\w].")
 
-        file = args[0]
-        # Calculate relative path
-        path_to_file = os.path.relpath(file, path_to_tx)
+    if not options.subcommand:
+        bare_set(path_to_tx, options)
+    elif options.subcommand == 'auto-local':
+        subcommand_autolocal(path_to_tx, options, from_wizard=from_wizard)
+    elif options.subcommand == 'auto-remote':
+        subcommand_autolocal(path_to_tx, options)
+    else:
+        parser.print_help()
+
+
+def bare_set(path_to_tx, options, from_wizard=False):
+    filename = options.filename
+    # Calculate relative path
+    path_to_file = os.path.relpath(filename, path_to_tx)
+
+    if options.is_source:
+        resource = options.resource
         _set_source_file(path_to_tx, resource, options.language, path_to_file)
     elif options.resource or options.language:
         resource = options.resource
         lang = options.language
 
-        if len(args) != 1:
-            parser.error("Please specify a file")
-
-        # Calculate relative path
-        path_to_file = os.path.relpath(args[0], path_to_tx)
-
         _go_to_dir(path_to_tx)
-
-        if not utils.valid_slug(resource):
-            parser.error("Invalid resource slug. The format is <project_slug>"
-                         ".<resource_slug> and the valid characters include "
-                         "[_-\w].")
         _set_translation(path_to_tx, resource, lang, path_to_file)
 
     _set_mode(options.resource, options.mode, path_to_tx)
@@ -198,7 +154,29 @@ def cmd_set(argv, path_to_tx):
     _set_minimum_perc(options.resource, options.minimum_perc, path_to_tx)
 
     logger.info("Done.")
-    return
+
+
+def subcommand_autolocal(path_to_tx, options, from_wizard=False):
+    expression = options.expression
+    _auto_local(path_to_tx, options.resource,
+                source_language=options.source_language,
+                expression=expression, source_file=options.source_file,
+                execute=options.execute, regex=False)
+    if options.execute:
+        _set_minimum_perc(options.resource, options.minimum_perc,
+                          path_to_tx)
+        _set_mode(options.resource, options.mode, path_to_tx)
+        _set_type(options.resource, options.i18n_type, path_to_tx)
+
+    if from_wizard:
+        _print_instructions(options.resource, path_to_tx)
+
+
+def subcommand_autoremote(path_to_tx, options):
+    url = options.project_url
+    _auto_remote(path_to_tx, url)
+    _set_minimum_perc(options.resource, options.minimum_perc, path_to_tx)
+    _set_mode(options.resource, options.mode, path_to_tx)
 
 
 def _print_instructions(resource, path_to_tx):
@@ -349,7 +327,7 @@ def _auto_remote(path_to_tx, url):
 def cmd_push(argv, path_to_tx):
     """Push local files to remote server"""
     parser = push_parser()
-    (options, args) = parser.parse_args(argv)
+    options = parser.parse_args(argv)
     force_creation = options.force_creation
     languages = parse_csv_option(options.languages)
     resources = parse_csv_option(options.resources)
@@ -374,7 +352,7 @@ def cmd_push(argv, path_to_tx):
 def cmd_pull(argv, path_to_tx):
     """Pull files from remote server to local repository"""
     parser = pull_parser()
-    (options, args) = parser.parse_args(argv)
+    options = parser.parse_args(argv)
     if options.fetchall and options.languages:
         parser.error("You can't user a language filter along with the "
                      "-a|--all option")
@@ -489,7 +467,7 @@ def _set_translation(path_to_tx, resource, lang, path_to_file):
 def cmd_status(argv, path_to_tx):
     """Print status of current project"""
     parser = status_parser()
-    (options, args) = parser.parse_args(argv)
+    options = parser.parse_args(argv)
     resources = parse_csv_option(options.resources)
     prj = project.Project(path_to_tx)
     resources = prj.get_chosen_resources(resources)
@@ -518,17 +496,15 @@ def cmd_status(argv, path_to_tx):
 def cmd_help(argv, path_to_tx):
     """List all available commands"""
     parser = help_parser()
-    (options, args) = parser.parse_args(argv)
-    if len(args) > 1:
-        parser.error("Multiple arguments received. Exiting...")
+    options = parser.parse_args(argv)
 
     # Get all commands
     fns = utils.discover_commands()
 
     # Print help for specific command
-    if len(args) == 1:
+    if options.command:
         try:
-            fns[argv[0]](['--help'], path_to_tx)
+            fns[options.command](['--help'], path_to_tx)
         except KeyError:
             utils.logger.error("Command %s not found" % argv[0])
     # or print summary of all commands
@@ -549,7 +525,7 @@ def cmd_help(argv, path_to_tx):
 def cmd_delete(argv, path_to_tx):
     """Delete an accessible resource or translation in a remote server."""
     parser = delete_parser()
-    (options, args) = parser.parse_args(argv)
+    options = parser.parse_args(argv)
     languages = parse_csv_option(options.languages)
     resources = parse_csv_option(options.resources)
     skip = options.skip_errors

--- a/txclib/messages.py
+++ b/txclib/messages.py
@@ -7,10 +7,10 @@ init_intro = """
   |_||_|  \__,_|_| |_|___/_|_|  \___/_/\_\\
 
 
-Welcome to Transifex Client! Please follow the instructions to
+Welcome to the Transifex Client! Please follow the instructions to
 initialize your project.
 """
-init_initialized = "It seems that this project is already intitialized."
+init_initialized = "It seems that this project is already initialized."
 
 init_reinit = "Do you want to delete it and reinit the project?"
 init_host = "Transifex instance"

--- a/txclib/messages.py
+++ b/txclib/messages.py
@@ -101,7 +101,7 @@ Here’s the content of the .tx/config file that was created:
 
 You could also have generated the same configuration by running a single command like:
 
-    tx set --auto-local -r {resource} -f {source_file} -s {source_lang} -t {type} '{file_filter}'
+    tx set auto-local -r {resource} -f {source_file} -s {source_lang} -t {type} '{file_filter}'
 
 To learn more about the Set command, visit https://docs.transifex.com/client/set.
 

--- a/txclib/messages.py
+++ b/txclib/messages.py
@@ -27,7 +27,7 @@ https://www.transifex.com/user/settings/api/.
 """
 update_txrc = "Overwrite credentials in .transifexrc?"
 
-token_msg = "[?] Please enter your api token: "
+token_msg = "[?] Enter your api token: "
 
 running_tx_set = "Running tx set command for you..."
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -351,6 +351,66 @@ def set_parser(subparser=False):
     return parser
 
 
+def set_multi_parser():
+    """Return the command-line parser for the set_multi command."""
+    usage = "usage: %prog [tx_options] set_multi [options] [args]"
+    description = "This command can be used to create a mapping between files "\
+        "and projects for multiple resources at once, using local files. " \
+                  "Always assumes --auto-local."
+    epilog = "\nExamples:\n"\
+        "To set a series of HTML source files that reside inside locale/:\n"\
+        " $ tx set_multi -p project 'expr' --source-lang en --type HTML " \
+        "-f '.html' -d locale\n\n"\
+        "To set a series of KEYVAlUEJSON source files that reside " \
+        "inside locale/ but exclude files in locale/es/ and locale/jp/:\n"\
+        " $ tx set_multi -p project 'expr' --source-lang en " \
+        "--type KEYVAlUEJSON -f '.json' -d locale -i es -i jp\n\n"
+    parser = EpilogParser(usage=usage, description=description, epilog=epilog)
+    parser.add_option("-p", "--project", action="store", dest="project",
+                      default=None,
+                      help="Specify the slug of the project that you're "
+                      "setting up.")
+    parser.add_option(
+        "-d", "--source-file-dir", action="store", dest="source_file_dir",
+        default=None, help=(
+            "Directory to find source files to be mapped. "
+            "Example: locale/en/"
+        )
+    )
+    parser.add_option("-t", "--type", action="store", dest="i18n_type",
+                      help=("Specify the i18n type of the resources. "
+                            "This is only needed, if the resource(s) does not "
+                            "exist yet in Transifex. For a list of "
+                            "available i18n types, see "
+                            "http://docs.transifex.com/formats/"
+                            ))
+    parser.add_option("-s", "--source-language", action="store",
+                      dest="source_language", default=None,
+                      help="Specify the source language of the resources ")
+    parser.add_option("-f", "--file-extension", action="store",
+                      dest="file_extension", default=None,
+                      help="File extension of files to be mapped.")
+    parser.add_option("-i", "--ignore-dir", action="append",
+                      dest="ignore_dirs", default=[],
+                      help="Directory to ignore while looking for source "
+                           "files. Can be called multiple times. "
+                           "Example: `-i es -i fr`.'.")
+    parser.add_option("--minimum-perc", action="store", dest="minimum_perc",
+                      help=("Specify the minimum acceptable percentage "
+                            "of a translation in order to download it."
+                            ))
+    parser.add_option(
+        "--mode", action="store", dest="mode", help=(
+            "Specify the mode of the translation file to pull (e.g. "
+            "'reviewed'). See http://bit.ly/pullmode for the "
+            "available values."
+        )
+    )
+    parser.add_option("--execute", action="store_true", dest="execute",
+                     default=False, help="Execute commands ")
+    return parser
+
+
 def status_parser():
     """Return the command-line parser for the status command."""
     description = "Prints the status of the current project by reading the "\

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -1,16 +1,53 @@
 # -*- coding: utf-8 -*-
 
-from optparse import OptionParser, OptionGroup
+import os
+import sys
+
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from txclib.utils import get_version
 
 
-class EpilogParser(OptionParser):
-    def format_epilog(self, formatter):
-        return self.epilog
+def tx_main_parser():
+    description = "This is the Transifex command line client which"\
+                  " allows you to manage your translations locally and sync"\
+                  " them with the master Transifex server.\nIf you'd like to"\
+                  " check the available commands issue `%(prog)s help` or if you"\
+                  " just want help with a specific command issue `%(prog)s help"\
+                  " command`"
+    version = get_version()
+    parser = ArgumentParser(
+        version=version, description=description, add_help=False
+    )
+    # parser.disable_interspersed_args()
+    parser.add_argument(
+        "-d", "--debug", action="store_true", dest="debug",
+        default=False, help=("enable debug messages")
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", dest="quiet",
+        default=False, help="don't print status messages to stdout"
+    )
+    parser.add_argument(
+        "--root", action="store", dest="root_dir", type=str,
+        default=None, help="change root directory (default is cwd)"
+    )
+    parser.add_argument(
+        "--traceback", action="store_true", dest="trace", default=False,
+        help="print full traceback on exceptions"
+    )
+    parser.add_argument(
+        "--disable-colors", action="store_true", dest="color_disable",
+        default=(os.name == 'nt' or not sys.stdout.isatty()),
+        help="disable colors in the output of commands"
+    )
+    parser.add_argument(
+        "command", action="store", help="TX command", nargs='?', default=None
+    )
+    return parser
 
 
 def delete_parser():
     """Return the command-line parser for the delete command."""
-    usage = "usage: %prog [tx_options] delete OPTION [OPTIONS]"
     description = (
         "This command deletes translations for a "
         "resource in the remote server."
@@ -21,20 +58,21 @@ def delete_parser():
         "$ tx delete -r project.resource -l <lang_code>\n\n"
         "To delete a resource:\n  $ tx delete -r project.resource\n"
     )
-    parser = EpilogParser(usage=usage, description=description, epilog=epilog)
-    parser.add_option(
+    parser = ArgumentParser(description=description, epilog=epilog,
+                            formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument(
         "-r", "--resource", action="store", dest="resources", default=None,
         help="Specify the resource you want to delete (defaults to all)"
     )
-    parser.add_option(
+    parser.add_argument(
         "-l", "--language", action="store", dest="languages",
         default=None, help="Specify the translation you want to delete"
     )
-    parser.add_option(
+    parser.add_argument(
         "--skip", action="store_true", dest="skip_errors", default=False,
         help="Don't stop on errors."
     )
-    parser.add_option(
+    parser.add_argument(
         "-f", "--force", action="store_true", dest="force_delete",
         default=False, help="Delete an entity forcefully."
     )
@@ -43,39 +81,39 @@ def delete_parser():
 
 def help_parser():
     """Return the command-line parser for the help command."""
-    usage = "usage: %prog help command"
     description = "Lists all available commands in the transifex command "\
-        "client. If a command is specified, the help page of the specific "\
+        "client. If a command is\nspecified, the help page of the specific "\
         "command is displayed instead."
 
-    parser = OptionParser(usage=usage, description=description)
+    parser = ArgumentParser(description=description)
+    parser.add_argument("command", action="store", nargs='?', default=None,
+                        help="One of the tx commands.")
     return parser
 
 
 def init_parser():
     """Return the command-line parser for the init command."""
-    usage = "usage: %prog [tx_options] init <path>"
     description = "This command initializes a new project for use with "\
         "Transifex. It is recommended to execute this command in the "\
         "top level directory of your project so that you can include "\
         "all files under it in transifex. If no path is provided, the "\
         "current working dir will be used."
-    parser = OptionParser(usage=usage, description=description)
-    parser.add_option("--host", action="store", dest="host", default=None,
-                      help="Specify a default Transifex host.")
-    parser.add_option("--user", action="store", dest="user", default=None,
-                      help="Specify username for Transifex server.")
-    parser.add_option("--pass", action="store", dest="password", default=None,
-                      help="Specify password for Transifex server.")
-    parser.add_option(
+    parser = ArgumentParser(description=description)
+    parser.add_argument("--host", action="store", dest="host", default=None,
+                        help="Specify a default Transifex host.")
+    parser.add_argument("--user", action="store", dest="user", default=None,
+                        help="Specify username for Transifex server.")
+    parser.add_argument("--pass", action="store", dest="password",
+                        default=None,
+                        help="Specify password for Transifex server.")
+    parser.add_argument(
         "--force-save",
         action="store_true",
         dest="save",
         default=False,
         help="Override .transifexrc file with the given credentials."
     )
-
-    parser.add_option(
+    parser.add_argument(
         "--skipsetup",
         action="store_true",
         dest="skipsetup",
@@ -83,83 +121,85 @@ def init_parser():
         help="Don't start tx set interactive wizard after setting up "
              "credentials."
     )
-    parser.add_option("--token", action="store", dest="token", default=None,
-                      help="Specify an api token.\nYou can get one from"
-                      " user's settings")
-    parser.add_option("--no-interactive", action="store_true",
-                      dest="no_interactive", default=False,
-                      help="Don't require user input when forcing a push.")
+    parser.add_argument("--token", action="store", dest="token", default=None,
+                        help="Specify an api token.\nYou can get one from"
+                        " user's settings")
+    parser.add_argument("--no-interactive", action="store_true",
+                        dest="no_interactive", default=False,
+                        help="Don't require user input when forcing a push.")
+    parser.add_argument("path_to_tx", action="store", nargs='?', default=None,
+                        help="Path to tx root folder.")
     return parser
 
 
 def pull_parser():
     """Return the command-line parser for the pull command."""
-    usage = "usage: %prog [tx_options] pull [options]"
-    description = "This command pulls all outstanding changes from the remote "\
+    description = \
+        "This command pulls all outstanding changes from the remote "\
         "Transifex server to the local repository. By default, only the "\
         "files that are watched by Transifex will be updated but if you "\
         "want to fetch the translations for new languages as well, use the "\
-        "-a|--all option. (Note: new translations are saved in the .tx folder "\
-        "and require the user to manually rename them and add then in "\
+        "-a|--all option. (Note: new translations are saved in the .tx "\
+        "folder and require the user to manually rename them and add then in "\
         "Transifex using the set_translation command)."
-    parser = OptionParser(usage=usage, description=description)
-    parser.add_option("-l", "--language", action="store", dest="languages",
-                      default=[], help="Specify which translations "
-                      "you want to pull (defaults to all)")
-    parser.add_option("-r", "--resource", action="store", dest="resources",
-                      default=[], help="Specify the resource for which you "
-                      "want to pull the translations (defaults to all)")
-    parser.add_option("-a", "--all", action="store_true", dest="fetchall",
-                      default=False, help="Fetch all translation files from "
-                      "server (even new ones)")
-    parser.add_option("-s", "--source", action="store_true",
-                      dest="fetchsource", default=False,
-                      help="Force the fetching of the source file (default: "
-                      "False)")
-    parser.add_option("-f", "--force", action="store_true", dest="force",
-                      default=False, help="Force download of translations "
-                      "files.")
-    parser.add_option("--skip", action="store_true", dest="skip_errors",
-                      default=False, help="Don't stop on errors. Useful when "
-                      "pushing many files concurrently.")
-    parser.add_option("--disable-overwrite", action="store_false",
-                      dest="overwrite", default=True,
-                      help="By default transifex will fetch new translations "
-                      "files and replace existing ones. Use this flag if you "
-                      "want to disable this feature")
-    parser.add_option("--minimum-perc", action="store", type="int",
-                      dest="minimum_perc", default=0,
-                      help="Specify the minimum acceptable percentage of "
-                      "a translation in order to download it.")
-    parser.add_option("--pseudo", action="store_true", dest="pseudo",
-                      default=False, help="Apply this option to download "
-                      "a pseudo file.")
-    parser.add_option(
+    parser = ArgumentParser(description=description)
+    parser.add_argument("-l", "--language", action="store", dest="languages",
+                        default=[], help="Specify which translations "
+                        "you want to pull (defaults to all)")
+    parser.add_argument("-r", "--resource", action="store", dest="resources",
+                        default=[], help="Specify the resource for which you "
+                        "want to pull the translations (defaults to all)")
+    parser.add_argument("-a", "--all", action="store_true", dest="fetchall",
+                        default=False, help="Fetch all translation files from "
+                        "server (even new ones)")
+    parser.add_argument("-s", "--source", action="store_true",
+                        dest="fetchsource", default=False,
+                        help="Force the fetching of the source file (default: "
+                        "False)")
+    parser.add_argument("-f", "--force", action="store_true", dest="force",
+                        default=False, help="Force download of translations "
+                        "files.")
+    parser.add_argument("--skip", action="store_true", dest="skip_errors",
+                        default=False, help="Don't stop on errors. Useful "
+                        "when pushing many files concurrently.")
+    parser.add_argument("--disable-overwrite", action="store_false",
+                        dest="overwrite", default=True,
+                        help="By default transifex will fetch new translations "
+                        "files and replace existing ones. Use this flag if you "
+                        "want to disable this feature")
+    parser.add_argument("--minimum-perc", action="store", type=int,
+                        dest="minimum_perc", default=0,
+                        help="Specify the minimum acceptable percentage of "
+                        "a translation in order to download it.")
+    parser.add_argument("--pseudo", action="store_true", dest="pseudo",
+                        default=False, help="Apply this option to download "
+                        "a pseudo file.")
+    parser.add_argument(
         "--mode", action="store", dest="mode", help=(
             "Specify the mode of the translation file to pull (e.g. "
             "'reviewed'). See http://bit.ly/pullmode for available values."
         )
     )
-    parser.add_option(
+    parser.add_argument(
         "-b", "--branch", action="store_true", dest="branch",
         default=False,
         help=("Push to a specific branch. Default is current"
               "branch if exists.")
     )
-    parser.add_option(
+    parser.add_argument(
         "--branchname", action="store", dest="branchname",
         help=("Specify the branch name to which we are going to push.")
     )
-    parser.add_option("-x", "--xliff", action="store_true", dest="xliff",
-                      default=False, help="Apply this option to download "
-                      "file as xliff.")
+    parser.add_argument("-x", "--xliff", action="store_true", dest="xliff",
+                        default=False, help="Apply this option to download "
+                        "file as xliff.")
     return parser
 
 
 def push_parser():
     """Return the command-line parser for the push command."""
-    usage = "usage: %prog [tx_options] push [options]"
-    description = "This command pushes all local files that have been added to "\
+    description = \
+        "This command pushes all local files that have been added to "\
         "Transifex to the remote server. All new translations are merged "\
         "with existing ones and if a language doesn't exists then it gets "\
         "created. If you want to push the source file as well (either "\
@@ -167,40 +207,40 @@ def push_parser():
         "you just have updated with new entries), use the -f|--force option. "\
         "By default, this command will push all files which are watched by "\
         "Transifex but you can filter this per resource or/and language. "
-    parser = OptionParser(usage=usage, description=description)
-    parser.add_option("-l", "--language", action="store", dest="languages",
-                      default=None, help="Specify which translations you "
-                      "want to push (defaults to all)")
-    parser.add_option("-r", "--resource", action="store", dest="resources",
-                      default=None, help="Specify the resource for which you "
-                      "want to push the translations (defaults to all)")
-    parser.add_option("-f", "--force", action="store_true",
-                      dest="force_creation", default=False,
-                      help="Push source files without checking modification "
-                      "times.")
-    parser.add_option("--skip", action="store_true", dest="skip_errors",
-                      default=False, help="Don't stop on errors. "
-                      "Useful when pushing many files concurrently.")
-    parser.add_option("-s", "--source", action="store_true",
-                      dest="push_source", default=False,
-                      help="Push the source file to the server.")
+    parser = ArgumentParser(description=description)
+    parser.add_argument("-l", "--language", action="store", dest="languages",
+                        default=None, help="Specify which translations you "
+                        "want to push (defaults to all)")
+    parser.add_argument("-r", "--resource", action="store", dest="resources",
+                        default=None, help="Specify the resource for which "
+                        "you want to push the translations (defaults to all)")
+    parser.add_argument("-f", "--force", action="store_true",
+                        dest="force_creation", default=False,
+                        help="Push source files without checking modification "
+                        "times.")
+    parser.add_argument("--skip", action="store_true", dest="skip_errors",
+                        default=False, help="Don't stop on errors. "
+                        "Useful when pushing many files concurrently.")
+    parser.add_argument("-s", "--source", action="store_true",
+                        dest="push_source", default=False,
+                        help="Push the source file to the server.")
 
-    parser.add_option("-t", "--translations", action="store_true",
-                      dest="push_translations", default=False,
-                      help="Push the translation files to the server")
-    parser.add_option("--no-interactive", action="store_true",
-                      dest="no_interactive", default=False,
-                      help="Don't require user input when forcing a push.")
-    parser.add_option("-x", "--xliff", action="store_true", dest="xliff",
-                      default=False, help="Apply this option to upload "
-                      "file as xliff.")
-    parser.add_option(
+    parser.add_argument("-t", "--translations", action="store_true",
+                        dest="push_translations", default=False,
+                        help="Push the translation files to the server")
+    parser.add_argument("--no-interactive", action="store_true",
+                        dest="no_interactive", default=False,
+                        help="Don't require user input when forcing a push.")
+    parser.add_argument("-x", "--xliff", action="store_true", dest="xliff",
+                        default=False, help="Apply this option to upload "
+                        "file as xliff.")
+    parser.add_argument(
         "-b", "--branch", action="store_true", dest="branch",
         default=False,
         help=("Pull for a specific branch. Default is current"
               "branch if exists.")
     )
-    parser.add_option(
+    parser.add_argument(
         "--branchname", action="store", dest="branchname",
         help=("Specify the branch name for which the resources "
               "we are going to pull.")
@@ -208,12 +248,56 @@ def push_parser():
     return parser
 
 
-def set_parser():
+def set_main_parser():
+    main_parser = ArgumentParser(add_help=False)
+    main_parser.add_argument("-r", "--resource", action="store", dest="resource",
+                      required=True,
+                      help="Specify the slug of the resource that you're "
+                      "setting up (This must be in the following format: "
+                      "`project_slug.resource_slug`).")
+    main_parser.add_argument(
+        "--source", action="store_true", dest="is_source", default=False,
+        help=(
+            "Specify that the given file is a source file "
+            "[doesn't work with the --auto-* commands]."
+        )
+    )
+    main_parser.add_argument("-l", "--language", action="store",
+                             dest="language", default=None,
+                             help="Specify the source language of the "
+                             "resource")
+    main_parser.add_argument("-t", "--type", action="store", dest="i18n_type",
+                             help=("Specify the i18n type of the resource(s). "
+                                   "This is only needed, if the resource(s) "
+                                   "does not exist yet in Transifex. For a "
+                                   "list of available i18n types, see "
+                                   "http://docs.transifex.com/formats/"
+                                   ))
+    return main_parser
+
+
+def set_extra_parser():
+    extra_parser = ArgumentParser(add_help=False)
+    extra_parser.add_argument("--minimum-perc", action="store",
+                              dest="minimum_perc",
+                              help=("Specify the minimum acceptable "
+                                    "percentage of a translation in "
+                                    "order to download it."))
+    extra_parser.add_argument(
+        "--mode", action="store", dest="mode", help=(
+            "Specify the mode of the translation file to pull (e.g. "
+            "'reviewed'). See http://bit.ly/pullmode for the "
+            "available values."
+        )
+    )
+    return extra_parser
+
+
+def set_parser(subparser=False):
     """Return the command-line parser for the set command."""
-    usage = "usage: %prog [tx_options] set [options] [args]"
-    description = "This command can be used to create a mapping between files "\
-        "and projects either using local files or using files from a remote "\
-        "Transifex server."
+    description = "This command can be used to create a mapping between "\
+        "files and projects either\nusing local files or using files from a "\
+        "remote Transifex server."
     epilog = "\nExamples:\n"\
         "To set the source file:\n  $ tx set -r project.resource --source -l en <file>\n\n"\
         "To set a single translation file:\n  $ tx set -r project.resource -l de <file>\n\n"\
@@ -224,72 +308,56 @@ def set_parser():
         "--source-file <file>\n\n"\
         "To set a remote resource/project:\n"\
         "  $ tx set --auto-remote <transifex-url>\n"
-    parser = EpilogParser(usage=usage, description=description, epilog=epilog)
-    parser.add_option("--auto-local", action="store_true",
-                      dest="local", default=False,
-                      help="Used when auto configuring local project.")
-    parser.add_option("--auto-remote", action="store_true",
-                      dest="remote", default=False,
-                      help="Used when adding remote files from Transifex "
-                      "server.")
-    parser.add_option("-r", "--resource", action="store", dest="resource",
-                      default=None,
-                      help="Specify the slug of the resource that you're "
-                      "setting up (This must be in the following format: "
-                      "`project_slug.resource_slug`).")
-    parser.add_option(
-        "--source", action="store_true", dest="is_source", default=False,
-        help=(
-            "Specify that the given file is a source file "
-            "[doesn't work with the --auto-* commands]."
-        )
+    main_parser = set_main_parser()
+    extra_parser = set_extra_parser()
+    if subparser:
+        parents = []
+    else:
+        parents = [main_parser, extra_parser]
+
+    parser = ArgumentParser(
+        description=description, epilog=epilog, parents=parents,
+        formatter_class=RawDescriptionHelpFormatter
     )
-    parser.add_option("-l", "--language", action="store", dest="language",
-                      default=None,
-                      help="Specify which translations you want to pull "
-                      "[doesn't work with the --auto-* commands].")
-    parser.add_option("-t", "--type", action="store", dest="i18n_type",
-                      help=("Specify the i18n type of the resource(s). "
-                            "This is only needed, if the resource(s) does not "
-                            "exist yet in Transifex. For a list of "
-                            "available i18n types, see "
-                            "http://docs.transifex.com/formats/"
-                            ))
-    parser.add_option("--minimum-perc", action="store", dest="minimum_perc",
-                      help=("Specify the minimum acceptable percentage "
-                            "of a translation in order to download it."
-                            ))
-    parser.add_option(
-        "--mode", action="store", dest="mode", help=(
-            "Specify the mode of the translation file to pull (e.g. "
-            "'reviewed'). See http://bit.ly/pullmode for the "
-            "available values."
-        )
-    )
-    group = OptionGroup(parser, "Extended options", "These options can only "
-                                "be used with the --auto-local command.")
-    group.add_option("-s", "--source-language", action="store",
-                     dest="source_language", default=None,
-                     help="Specify the source language of a resource "
-                     "[requires --auto-local].")
-    group.add_option("-f", "--source-file", action="store", dest="source_file",
-                     default=None, help="Specify the source file of a "
-                     "resource [requires --auto-local].")
-    group.add_option("--execute", action="store_true", dest="execute",
-                     default=False, help="Execute commands "
-                     "[requires --auto-local].")
-    parser.add_option_group(group)
+    if not subparser:
+        parser.add_argument("filename", action="store", help="Source file path")
+
+    # else
+    subparsers = parser.add_subparsers(
+        title='subcommands', dest='subcommand')
+    auto_local_parser = subparsers.add_parser(
+        "auto-local", parents=[main_parser, extra_parser],
+        help="Use to auto configuring local project.")
+    auto_remote_parser = subparsers.add_parser(
+        "auto-remote", parents=[extra_parser],
+        help="Use to configure remote files from Transifex server.")
+
+    auto_local_parser.add_argument(
+        "--source-language", action="store", dest="source_language",
+        default=False, help="Source language of the resource.", required=True)
+    auto_local_parser.add_argument(
+        "-f", "--source-file", action="store", dest="source_file", default=None,
+        help="Specify the source file of a resource [requires --auto-local].")
+    auto_local_parser.add_argument(
+        "--execute", action="store_true", dest="execute",
+        default=False, help="Execute commands.")
+
+    auto_local_parser.add_argument("expression", action="store",
+                                   help=("File filter expression."))
+
+    auto_remote_parser.add_argument("project_url", action="store",
+                                    help="Url of Transifex project.")
+
     return parser
 
 
 def status_parser():
     """Return the command-line parser for the status command."""
-    usage = "usage: %prog [tx_options] status [options]"
     description = "Prints the status of the current project by reading the "\
                   "data in the configuration file."
-    parser = OptionParser(usage=usage, description=description)
-    parser.add_option("-r", "--resource", action="store", dest="resources",
-                      default=[], help="Specify resources")
+    parser = ArgumentParser(description=description)
+    parser.add_argument("-r", "--resource", action="store", dest="resources",
+                        default=[], help="Specify resources")
     return parser
 
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -304,12 +304,12 @@ def set_parser(subparser=False):
         $ tx set -r project.resource --source -l en <file>\n\n"\
         "To set a single translation file:\n\
         $ tx set -r project.resource -l de <file>\n"
-    auto_local_description = "This command can be used to create a mapping for "\
-                             "a local file using the expression argument "\
-                             "to automatically detect source and translation "\
-                             "files."
-    auto_remote_description = "This command can be used to create mappings for "\
-                              "resources existing on the remote server."
+    auto_local_description = "This command can be used to create a mapping "\
+                             "for a local file using the path expression "\
+                             "argument to automatically detect source and "\
+                             "translation files."
+    auto_remote_description = "This command can be used to create mappings "\
+                              "for resources existing on the remote server."
     auto_local_epilog = "\nExamples:\n"\
         "To automatically detect and assign the source file and translations:"\
         "\n $ %(prog)s -r project.resource 'expr' --source-language en\n\n"\
@@ -369,7 +369,12 @@ def set_parser(subparser=False):
         "--execute", action="store_true", dest="execute", default=False,
         help="Execute commands.")
     auto_local_parser.add_argument(
-        "expression", action="store", help="File filter expression.")
+        "expression", action="store",
+        help="A path expression pointing to the location where translation "
+             "files for the associated source file are/will be saved. Use "
+             "<lang> as a wildcard for the language code, "
+             "e.g. translations/<lang>/test.txt."
+    )
 
     # auto-remote subparser
     auto_remote_parser = subparsers.add_parser(
@@ -418,7 +423,12 @@ def set_parser(subparser=False):
         help="Directory to ignore while looking for source "
              "files. Can be called multiple times. Example: `-i es -i fr`.'.")
     auto_bulk_parser.add_argument(
-        "expression", action="store", help="File filter expression.")
+        "expression", action="store",
+        help="A path expression pointing to the location where translation "
+             "files for the associated source file are/will be saved. Use "
+             "<lang> as a wildcard for the language code, "
+             "e.g. translations/<lang>/test.txt."
+    )
     auto_bulk_parser.add_argument(
         "--execute", action="store_true", dest="execute", default=False,
         help="Execute commands.")

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -313,11 +313,11 @@ def set_parser(subparser=False):
         "files and projects for multiple resources at once, using local files."
     bulk_epilog = "\nExamples:\n"\
         "To set a series of HTML source files that reside inside locale/:\n"\
-        " $ %(prog)s -p project 'expression' --source-lang en --type HTML " \
+        " $ %(prog)s -p project 'expression' --source-language en --type HTML " \
         "-f '.html' -d locale\n\n"\
         "To set a series of KEYVAlUEJSON source files that reside " \
         "inside locale/ but exclude files in locale/es/ and locale/jp/:\n"\
-        " $ %(prog)s -p project 'expr' --source-lang en " \
+        " $ %(prog)s -p project 'expr' --source-language en " \
         "--type KEYVAlUEJSON -f '.json' -d locale -i es -i jp\n\n"
 
     main_parser = set_main_parser()
@@ -349,7 +349,7 @@ def set_parser(subparser=False):
         help="Use to auto configuring local project."
     )
     auto_local_parser.add_argument(
-        "--source-language", action="store", dest="source_language",
+        "-s", "--source-language", action="store", dest="source_language",
         default=False, required=True, help="Source language of the resource.")
     auto_local_parser.add_argument(
         "-f", "--source-file", action="store", dest="source_file",

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -11,9 +11,9 @@ def tx_main_parser():
     description = "This is the Transifex command line client which"\
                   " allows you to manage your translations locally and sync"\
                   " them with the master Transifex server.\nIf you'd like to"\
-                  " check the available commands issue `%(prog)s help` or if you"\
-                  " just want help with a specific command issue `%(prog)s help"\
-                  " command`"
+                  " check the available commands issue `%(prog)s help` or if"\
+                  " you just want help with a specific command issue"\
+                  " `%(prog)s help command`"
     version = get_version()
     parser = ArgumentParser(
         version=version, description=description, add_help=False
@@ -164,9 +164,9 @@ def pull_parser():
                         "when pushing many files concurrently.")
     parser.add_argument("--disable-overwrite", action="store_false",
                         dest="overwrite", default=True,
-                        help="By default transifex will fetch new translations "
-                        "files and replace existing ones. Use this flag if you "
-                        "want to disable this feature")
+                        help="By default transifex will fetch new translations"
+                        " files and replace existing ones. Use this flag if"
+                        " you want to disable this feature")
     parser.add_argument("--minimum-perc", action="store", type=int,
                         dest="minimum_perc", default=0,
                         help="Specify the minimum acceptable percentage of "
@@ -250,17 +250,14 @@ def push_parser():
 
 def set_main_parser():
     main_parser = ArgumentParser(add_help=False)
-    main_parser.add_argument("-r", "--resource", action="store", dest="resource",
-                      required=True,
-                      help="Specify the slug of the resource that you're "
-                      "setting up (This must be in the following format: "
-                      "`project_slug.resource_slug`).")
+    main_parser.add_argument(
+        "-r", "--resource", action="store", dest="resource", required=True,
+        help="Specify the slug of the resource that you're setting up "
+        "(This must be in the following format: `project_slug.resource_slug`)."
+    )
     main_parser.add_argument(
         "--source", action="store_true", dest="is_source", default=False,
-        help=(
-            "Specify that the given file is a source file "
-            "[doesn't work with the --auto-* commands]."
-        )
+        help="Specify that the given file is a source file."
     )
     main_parser.add_argument("-l", "--language", action="store",
                              dest="language", default=None,
@@ -299,19 +296,21 @@ def set_parser(subparser=False):
         "files and projects either\nusing local files or using files from a "\
         "remote Transifex server."
     epilog = "\nExamples:\n"\
-        "To set the source file:\n  $ tx set -r project.resource --source -l en <file>\n\n"\
-        "To set a single translation file:\n  $ tx set -r project.resource -l de <file>\n"
+        "To set the source file:\n\
+        $ tx set -r project.resource --source -l en <file>\n\n"\
+        "To set a single translation file:\n\
+        $ tx set -r project.resource -l de <file>\n"
     auto_local_epilog = "\nExamples:\n"\
-        "To automatically detect and assign the source files and translations:\n"\
-        " $ %(prog)s -r project.resource 'expr' --source-language en\n\n"\
+        "To automatically detect and assign the source file and translations:"\
+        "\n $ %(prog)s -r project.resource 'expr' --source-language en\n\n"\
         "To set a specific file as a source and auto detect translations:\n"\
         " $ %(prog)s -r project.resource 'expr' --source-language en "\
         "--source-file <file>\n\n"
     auto_remote_epilog = "\nExamples:\n"\
         "To set a remote resource/project:\n"\
         "  $ %(prog)s <transifex-url>\n"
-    bulk_description = "This command can be used to create a mapping between files "\
-        "and projects for multiple resources at once, using local files."
+    bulk_description = "This command can be used to create a mapping between "\
+        "files and projects for multiple resources at once, using local files."
     bulk_epilog = "\nExamples:\n"\
         "To set a series of HTML source files that reside inside locale/:\n"\
         " $ %(prog)s -p project 'expression' --source-lang en --type HTML " \
@@ -332,27 +331,34 @@ def set_parser(subparser=False):
         description=description, epilog=epilog, parents=parents,
         formatter_class=RawDescriptionHelpFormatter
     )
+    # return parser that should be used when set is run without a subcommand
     if not subparser:
-        parser.add_argument("filename", action="store", help="Source file path")
+        parser.add_argument(
+            "filename", action="store",
+            help="The source or translation file of the resource."
+        )
         return parser
 
     # SUBPARSERS
     # auto-local subparser
     subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
     auto_local_parser = subparsers.add_parser(
-        "auto-local", prog="tx set auto-local", parents=[main_parser, extra_parser],
-        epilog=auto_local_epilog, formatter_class=RawDescriptionHelpFormatter,
+        "auto-local", prog="tx set auto-local",
+        parents=[main_parser, extra_parser], epilog=auto_local_epilog,
+        formatter_class=RawDescriptionHelpFormatter,
         help="Use to auto configuring local project."
     )
-    auto_local_parser.add_argument("--source-language", action="store", dest="source_language",
-                     default=False, help="Source language of the resource.", required=True)
-    auto_local_parser.add_argument("-f", "--source-file", action="store", dest="source_file",
-                     default=None, help="Specify the source file of a "
-                     "resource [requires --auto-local].")
-    auto_local_parser.add_argument("--execute", action="store_true", dest="execute",
-                     default=False, help="Execute commands.")
-    auto_local_parser.add_argument("expression", action="store",
-                                   help=("File filter expression."))
+    auto_local_parser.add_argument(
+        "--source-language", action="store", dest="source_language",
+        default=False, required=True, help="Source language of the resource.")
+    auto_local_parser.add_argument(
+        "-f", "--source-file", action="store", dest="source_file",
+        default=None, help="Specify the source file of a resource.")
+    auto_local_parser.add_argument(
+        "--execute", action="store_true", dest="execute", default=False,
+        help="Execute commands.")
+    auto_local_parser.add_argument(
+        "expression", action="store", help="File filter expression.")
 
     # auto-remote subparser
     auto_remote_parser = subparsers.add_parser(
@@ -364,13 +370,16 @@ def set_parser(subparser=False):
                                     help="Url of Transifex project.")
     # auto-bulk subparser
     auto_bulk_parser = subparsers.add_parser(
-        "bulk", parents=[extra_parser], prog="tx set bulk", description=description,
-        epilog=bulk_epilog, help="Use to configure remote files from Transifex server.",
+        "bulk", parents=[extra_parser], prog="tx set bulk",
+        description=bulk_description, epilog=bulk_epilog,
+        help="Use to auto configure multiple local files.",
         formatter_class=RawDescriptionHelpFormatter
     )
-    auto_bulk_parser.add_argument("-p", "--project", action="store", dest="project",
-                      default=None, required=True,
-                      help="Specify the slug of the project that you're setting up.")
+    auto_bulk_parser.add_argument(
+        "-p", "--project", action="store", dest="project", default=None,
+        required=True,
+        help="Specify the slug of the project that you're setting up."
+    )
     auto_bulk_parser.add_argument(
         "--source-file-dir", action="store", dest="source_file_dir",
         default=None, required=True, help=(
@@ -378,28 +387,29 @@ def set_parser(subparser=False):
             "Example: locale/en/"
         )
     )
-    auto_bulk_parser.add_argument("-t", "--type", action="store", dest="i18n_type",
-                      help=("Specify the i18n type of the resources. "
-                            "This is only needed, if the resource(s) does not "
-                            "exist yet in Transifex. For a list of "
-                            "available i18n types, see "
-                            "http://docs.transifex.com/formats/"
-                            ))
-    auto_bulk_parser.add_argument("-s", "--source-language", action="store",
-                      dest="source_language", default=None, required=True,
-                      help="Specify the source language of the resources ")
-    auto_bulk_parser.add_argument("-f", "--file-extension", action="store",
-                      dest="file_extension", default=None, required=True,
-                      help="File extension of files to be mapped.")
-    auto_bulk_parser.add_argument("-i", "--ignore-dir", action="append",
-                      dest="ignore_dirs", default=[],
-                      help="Directory to ignore while looking for source "
-                           "files. Can be called multiple times. "
-                           "Example: `-i es -i fr`.'.")
-    auto_bulk_parser.add_argument("expression", action="store",
-                                   help=("File filter expression."))
-    auto_bulk_parser.add_argument("--execute", action="store_true", dest="execute",
-                     default=False, help="Execute commands ")
+    auto_bulk_parser.add_argument(
+        "-t", "--type", action="store", dest="i18n_type",
+        help="Specify the i18n type of the resources. This is only needed, "
+             "if the resource(s) does not exist yet in Transifex. For a list "
+             "of available i18n types, see http://docs.transifex.com/formats/"
+    )
+    auto_bulk_parser.add_argument(
+        "-s", "--source-language", action="store", dest="source_language",
+        default=None, required=True,
+        help="Specify the source language of the resources ")
+    auto_bulk_parser.add_argument(
+        "-f", "--file-extension", action="store", dest="file_extension",
+        default=None, required=True,
+        help="File extension of files to be mapped.")
+    auto_bulk_parser.add_argument(
+        "-i", "--ignore-dir", action="append", dest="ignore_dirs", default=[],
+        help="Directory to ignore while looking for source "
+             "files. Can be called multiple times. Example: `-i es -i fr`.'.")
+    auto_bulk_parser.add_argument(
+        "expression", action="store", help="File filter expression.")
+    auto_bulk_parser.add_argument(
+        "--execute", action="store_true", dest="execute", default=False,
+        help="Execute commands.")
     return parser
 
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -322,91 +322,72 @@ def set_parser(subparser=False):
     if not subparser:
         parser.add_argument("filename", action="store", help="Source file path")
 
-    # else
-    subparsers = parser.add_subparsers(
-        title='subcommands', dest='subcommand')
-    auto_local_parser = subparsers.add_parser(
-        "auto-local", parents=[main_parser, extra_parser],
-        help="Use to auto configuring local project.")
-    auto_remote_parser = subparsers.add_parser(
-        "auto-remote", parents=[extra_parser],
-        help="Use to configure remote files from Transifex server.")
-
-    auto_local_parser.add_argument(
-        "--source-language", action="store", dest="source_language",
-        default=False, help="Source language of the resource.", required=True)
-    auto_local_parser.add_argument(
-        "-f", "--source-file", action="store", dest="source_file", default=None,
-        help="Specify the source file of a resource [requires --auto-local].")
-    auto_local_parser.add_argument(
-        "--execute", action="store_true", dest="execute",
-        default=False, help="Execute commands.")
-
+    # SUBPARSERS
+    # auto-local subparser
+    subparsers = set_parser.add_subparsers(title='subcommands', dest='subcommand')
+    auto_local_parser = subparsers.add_parser("auto-local", parents=[main_parser, extra_parser],
+                      help="Use to auto configuring local project.")
+    auto_local_parser.add_argument("--source-language", action="store", dest="source_language",
+                     default=False, help="Source language of the resource.", required=True)
+    auto_local_parser.add_argument("-f", "--source-file", action="store", dest="source_file",
+                     default=None, help="Specify the source file of a "
+                     "resource [requires --auto-local].")
+    auto_local_parser.add_argument("--execute", action="store_true", dest="execute",
+                     default=False, help="Execute commands.")
     auto_local_parser.add_argument("expression", action="store",
                                    help=("File filter expression."))
 
+    # auto-remote subparser
+    auto_remote_parser = subparsers.add_parser("auto-remote", parents=[extra_parser],
+                      help="Use to configure remote files from Transifex server.")
     auto_remote_parser.add_argument("project_url", action="store",
                                     help="Url of Transifex project.")
-
-    return parser
-
-
-def set_multi_parser():
-    """Return the command-line parser for the set_multi command."""
-    usage = "usage: %prog [tx_options] set_multi [options] [args]"
+    # auto-bulk subparser
     description = "This command can be used to create a mapping between files "\
         "and projects for multiple resources at once, using local files. " \
                   "Always assumes --auto-local."
     epilog = "\nExamples:\n"\
         "To set a series of HTML source files that reside inside locale/:\n"\
-        " $ tx set_multi -p project 'expr' --source-lang en --type HTML " \
+        " $ tx set_multi -p project 'expression' --source-lang en --type HTML " \
         "-f '.html' -d locale\n\n"\
         "To set a series of KEYVAlUEJSON source files that reside " \
         "inside locale/ but exclude files in locale/es/ and locale/jp/:\n"\
         " $ tx set_multi -p project 'expr' --source-lang en " \
         "--type KEYVAlUEJSON -f '.json' -d locale -i es -i jp\n\n"
-    parser = EpilogParser(usage=usage, description=description, epilog=epilog)
-    parser.add_option("-p", "--project", action="store", dest="project",
-                      default=None,
-                      help="Specify the slug of the project that you're "
-                      "setting up.")
-    parser.add_option(
+    auto_bulk_parser = subparsers.add_parser("auto-bulk", parents=[extra_parser],
+                      help="Use to configure remote files from Transifex server.",
+                      description=description, epilog=epilog)
+    auto_bulk_parser.add_argument("-p", "--project", action="store", dest="project",
+                      default=None, required=True,
+                      help="Specify the slug of the project that you're setting up.")
+    auto_bulk_parser.add_argument(
         "-d", "--source-file-dir", action="store", dest="source_file_dir",
-        default=None, help=(
+        default=None, required=True, help=(
             "Directory to find source files to be mapped. "
             "Example: locale/en/"
         )
     )
-    parser.add_option("-t", "--type", action="store", dest="i18n_type",
+    auto_bulk_parser.add_argument("-t", "--type", action="store", dest="i18n_type",
                       help=("Specify the i18n type of the resources. "
                             "This is only needed, if the resource(s) does not "
                             "exist yet in Transifex. For a list of "
                             "available i18n types, see "
                             "http://docs.transifex.com/formats/"
                             ))
-    parser.add_option("-s", "--source-language", action="store",
-                      dest="source_language", default=None,
+    auto_bulk_parser.add_argument("-s", "--source-language", action="store",
+                      dest="source_language", default=None, required=True,
                       help="Specify the source language of the resources ")
-    parser.add_option("-f", "--file-extension", action="store",
-                      dest="file_extension", default=None,
+    auto_bulk_parser.add_argument("-f", "--file-extension", action="store",
+                      dest="file_extension", default=None, required=True,
                       help="File extension of files to be mapped.")
-    parser.add_option("-i", "--ignore-dir", action="append",
+    auto_bulk_parser.add_argument("-i", "--ignore-dir", action="append",
                       dest="ignore_dirs", default=[],
                       help="Directory to ignore while looking for source "
                            "files. Can be called multiple times. "
                            "Example: `-i es -i fr`.'.")
-    parser.add_option("--minimum-perc", action="store", dest="minimum_perc",
-                      help=("Specify the minimum acceptable percentage "
-                            "of a translation in order to download it."
-                            ))
-    parser.add_option(
-        "--mode", action="store", dest="mode", help=(
-            "Specify the mode of the translation file to pull (e.g. "
-            "'reviewed'). See http://bit.ly/pullmode for the "
-            "available values."
-        )
-    )
-    parser.add_option("--execute", action="store_true", dest="execute",
+    auto_bulk_parser.add_argument("expression", action="store",
+                                   help=("File filter expression."))
+    auto_bulk_parser.add_argument("--execute", action="store_true", dest="execute",
                      default=False, help="Execute commands ")
     return parser
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -295,7 +295,11 @@ def set_parser(subparser=False):
     description = "This command can be used to create a mapping between "\
         "files and projects either\nusing local files or using files from a "\
         "remote Transifex server."
-    epilog = "\nExamples:\n"\
+    epilog = "\nSubcommands:\n"\
+        "    auto-local\n"\
+        "    auto-remote\n"\
+        "    bulk\n\n"\
+        "Examples:\n"\
         "To set the source file:\n\
         $ tx set -r project.resource --source -l en <file>\n\n"\
         "To set a single translation file:\n\
@@ -313,8 +317,8 @@ def set_parser(subparser=False):
         "files and projects for multiple resources at once, using local files."
     bulk_epilog = "\nExamples:\n"\
         "To set a series of HTML source files that reside inside locale/:\n"\
-        " $ %(prog)s -p project 'expression' --source-language en --type HTML " \
-        "-f '.html' -d locale\n\n"\
+        " $ %(prog)s -p project 'expression' --source-language en --type HTML"\
+        " -f '.html' -d locale\n\n"\
         "To set a series of KEYVAlUEJSON source files that reside " \
         "inside locale/ but exclude files in locale/es/ and locale/jp/:\n"\
         " $ %(prog)s -p project 'expr' --source-language en " \

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -304,6 +304,12 @@ def set_parser(subparser=False):
         $ tx set -r project.resource --source -l en <file>\n\n"\
         "To set a single translation file:\n\
         $ tx set -r project.resource -l de <file>\n"
+    auto_local_description = "This command can be used to create a mapping for "\
+                             "a local file using the expression argument "\
+                             "to automatically detect source and translation "\
+                             "files."
+    auto_remote_description = "This command can be used to create mappings for "\
+                              "resources existing on the remote server."
     auto_local_epilog = "\nExamples:\n"\
         "To automatically detect and assign the source file and translations:"\
         "\n $ %(prog)s -r project.resource 'expr' --source-language en\n\n"\
@@ -318,7 +324,7 @@ def set_parser(subparser=False):
     bulk_epilog = "\nExamples:\n"\
         "To set a series of HTML source files that reside inside locale/:\n"\
         " $ %(prog)s -p project 'expression' --source-language en --type HTML"\
-        " -f '.html' -d locale\n\n"\
+        " -f '.html' --source-file-dir locale\n\n"\
         "To set a series of KEYVAlUEJSON source files that reside " \
         "inside locale/ but exclude files in locale/es/ and locale/jp/:\n"\
         " $ %(prog)s -p project 'expr' --source-language en " \
@@ -349,6 +355,7 @@ def set_parser(subparser=False):
     auto_local_parser = subparsers.add_parser(
         "auto-local", prog="tx set auto-local",
         parents=[main_parser, extra_parser], epilog=auto_local_epilog,
+        description=auto_local_description,
         formatter_class=RawDescriptionHelpFormatter,
         help="Use to auto configuring local project."
     )
@@ -367,6 +374,7 @@ def set_parser(subparser=False):
     # auto-remote subparser
     auto_remote_parser = subparsers.add_parser(
         "auto-remote", parents=[extra_parser], prog="tx set auto-remote",
+        description=auto_remote_description,
         epilog=auto_remote_epilog, formatter_class=RawDescriptionHelpFormatter,
         help="Use to configure remote files from Transifex server."
     )

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -147,7 +147,6 @@ class Project(object):
         if save:
             logger.info("Updating %s file..." % self.txrc_file)
             if not self.txrc.has_section(host):
-                logger.info("No entry found for host %s. Creating..." % host)
                 self.txrc.add_section(host)
             self.txrc.set(host, 'username', username)
             self.txrc.set(host, 'password', password)

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -251,7 +251,7 @@ def valid_slug(slug):
     Check if a slug contains only valid characters.
     Valid chars include [-_\w]
     """
-    return re.match("^[A-Za-z0-9_-]*$", slug)
+    return re.match("^[A-Za-z0-9_-]+$", slug)
 
 
 def discover_commands():

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -233,19 +233,25 @@ def get_details(api_call, username, password, *args, **kwargs):
         raise
 
 
-def valid_slug(slug):
+def valid_resource_slug(slug):
     """
-    Check if a slug contains only valid characters.
-    Valid chars include [-_\w]
+    Check if a resource slug contains only valid characters.
+    Valid format is [-_\w].[-_\w] (<project>.<resource>)
     """
     try:
         a, b = slug.split('.')
     except ValueError:
         return False
     else:
-        if re.match("^[A-Za-z0-9_-]*$", a) and re.match("^[A-Za-z0-9_-]*$", b):
-            return True
-        return False
+        return valid_slug(a) and valid_slug(b)
+
+
+def valid_slug(slug):
+    """
+    Check if a slug contains only valid characters.
+    Valid chars include [-_\w]
+    """
+    return re.match("^[A-Za-z0-9_-]*$", slug)
 
 
 def discover_commands():

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -7,6 +7,8 @@ import errno
 import urllib3
 import collections
 import six
+import platform
+import txclib
 
 try:
     from json import loads as parse_json
@@ -555,3 +557,12 @@ def get_current_branch(root_dir):
             m = re.match('ref: refs/heads/(.+?)\s+$', ref)
             if m:
                 return m.group(1)
+
+
+def get_version():
+    return '%s, py %s.%s, %s' % (
+        txclib.__version__,
+        sys.version_info.major,
+        sys.version_info.minor,
+        platform.machine()
+    )

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -502,7 +502,7 @@ def get_transifex_file(directory=None):
     txrc_file = os.path.join(directory, ".transifexrc")
     logger.debug(".transifexrc file is at %s" % directory)
     if not os.path.exists(txrc_file):
-        msg = "%s not found." % (txrc_file)
+        msg = "No credentials file was found at %s." % (txrc_file)
         logger.info(msg)
         mask = os.umask(0o077)
         open(txrc_file, 'w').close()

--- a/txclib/wizard.py
+++ b/txclib/wizard.py
@@ -127,7 +127,7 @@ class Wizard(object):
         parser's options with the user input. Options `local` and `execute`
         are by default True when interactive wizard is run.
 
-        Returns: the populated (options, args) tuple.
+        Returns: the options dictionary.
         """
 
         TEXTS = messages.TEXTS
@@ -186,6 +186,5 @@ class Wizard(object):
             'i18n_type': i18n_type,
             'source_language': source_language,
             'resource': resource,
-            'execute': True,
         }
         return options

--- a/txclib/wizard.py
+++ b/txclib/wizard.py
@@ -186,5 +186,6 @@ class Wizard(object):
             'i18n_type': i18n_type,
             'source_language': source_language,
             'resource': resource,
+            'execute': True,
         }
         return options


### PR DESCRIPTION

## Problems
* Tx set --auto-local and --auto-remote functionality is independent of one another. Having this options on the same level as all the rest of the options created confusion.  
* When trying to set a lot of local files, you need to call a `set` command for each file separately. If you have lots of files, it takes a lot of time and it's not convenient.

## Solution
Create new subcommands for `tx set` command, namely `auto-local`, `auto-remote`, `bulk`. Each subcommand support it own options and positional arguments. Base `tx set` is still supported as before but only with the minimum options.

Example:

To set a series of HTML source files that reside inside `locale/`:
```
tx set bulk -p myproject 'locale/<lang>/{filepath}/{filename}{extension}' --source-language en --type HTML --file-extension '.html' -d locale
```

To set a series of KEYVALUEJSON source files that reside inside locale/ but exclude files in locale/es/ and locale/jp/:
```
tx set bulk -p myproject 'locale/<lang>/{filepath}/{filename}{extension}' --source-lang en --type KEYVALUEJSON --file-extension '.json' -d -i ko -i jp locale
``` 
To automatically detect and assign the source files and translations:
```
 tx set auto-local -r project.resource --source-language en 'translations/<lang>/source-file.txt'
```
To set a remote resource/project:
```
 tx set auto-remote <transifex-url>
```
### Notes for the reviewers
* As part of this PR optparse has been replaced with argparse, which natively supports subcommands offers better argument parsing and handling.
* It is helpful to do a `tx set --help`, `tx set auto-local --help`, etc.. to have a better picture of the supported functionality.