### PR TITLE
Don't use logger for regular output like help and status

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,9 @@
 import unittest
+import sys
+from StringIO import StringIO
+from mock import patch, MagicMock
 from txclib.commands import _set_source_file, _set_translation, cmd_pull, \
-    UnInitializedError
+    UnInitializedError, cmd_help, cmd_status
 
 
 class TestCommands(unittest.TestCase):
@@ -18,3 +21,38 @@ class TestCommands(unittest.TestCase):
         with self.assertRaises(UnInitializedError):
             _set_translation(path_to_tx=None, resource="dummy_resource.md",
                              lang='en', path_to_file='invalid')
+
+
+class TestStatusCommand(unittest.TestCase):
+    @patch('txclib.commands.project')
+    def test_status(self, mock_p):
+        """Test status command"""
+        mock_project = MagicMock()
+        mock_project.get_chosen_resources.return_value = ['foo.bar']
+        mock_project.get_resource_files.return_value = {
+            "fr": "translations/foo.bar/fr.po",
+            "de": "translations/foo.bar/de.po"
+        }
+        mock_p.Project.return_value = mock_project
+        cmd_status([], None)
+        mock_project.get_chosen_resources.assert_called_once_with([])
+        self.assertEqual(mock_project.get_resource_files.call_count, 1)
+
+
+class TestHelpCommand(unittest.TestCase):
+    def test_help(self):
+        out = StringIO()
+        sys.stdout = out
+        cmd_help([], None)
+        output = out.getvalue().strip()
+        self.assertTrue(
+            all(
+                c in output for c in
+                ['delete', 'help', 'init', 'pull', 'push', 'set', 'status']
+            )
+        )
+
+        # call for specific command
+        with patch('txclib.commands.cmd_pull', spec=cmd_pull) as pull_mock:
+            cmd_help(['pull'], None)
+            pull_mock.assert_called_once_with(['--help'], None)

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -50,7 +50,7 @@ def cmd_init(argv, path_to_tx):
     # if we already have a config file and we are not told to override it
     # in the args we have to ask
     if os.path.isdir(os.path.join(path_to_tx, ".tx")) and not save:
-        logger.info("tx: There is already a tx folder!")
+        logger.info("There is already a tx folder!")
         if not utils.confirm(
             prompt='Do you want to delete it and reinit the project?',
             default=False
@@ -473,13 +473,13 @@ def cmd_status(argv, path_to_tx):
     resources_num = len(resources)
     for idx, res in enumerate(resources):
         p, r = res.split('.')
-        logger.info("%s -> %s (%s of %s)" % (p, r, idx + 1, resources_num))
-        logger.info("Translation Files:")
+        print("%s -> %s (%s of %s)" % (p, r, idx + 1, resources_num))
+        print("Translation Files:")
         slang = prj.get_resource_option(res, 'source_lang')
         sfile = prj.get_resource_option(res, 'source_file') or "N/A"
         lang_map = prj.get_resource_lang_mapping(res)
-        logger.info(" - %s: %s (%s)" % (utils.color_text(slang, "RED"),
-                    sfile, utils.color_text("source", "YELLOW")))
+        print(" - %s: %s (%s)" % (utils.color_text(slang, "RED"),
+              sfile, utils.color_text("source", "YELLOW")))
         files = prj.get_resource_files(res)
         fkeys = list(files.keys())
         fkeys.sort()
@@ -487,9 +487,9 @@ def cmd_status(argv, path_to_tx):
             local_lang = lang
             if lang in list(lang_map.values()):
                 local_lang = lang_map.flip[lang]
-            logger.info(" - %s: %s" % (utils.color_text(local_lang, "RED"),
-                        files[lang]))
-        logger.info("")
+            print(" - %s: %s" % (utils.color_text(local_lang, "RED"),
+                  files[lang]))
+        print("")
 
 
 def cmd_help(argv, path_to_tx):
@@ -516,11 +516,11 @@ def cmd_help(argv, path_to_tx):
     keys = list(fns.keys())
     keys.sort()
 
-    logger.info("Transifex command line client.\n")
-    logger.info("Available commands are:")
+    print("Transifex command line client.\n")
+    print("Available commands are:")
     for key in keys:
-        logger.info("  %-15s\t%s" % (key, getattr(fns[key], '__doc__')))
-    logger.info("\nFor more information run %s command --help" % sys.argv[0])
+        print("  %-15s\t%s" % (key, getattr(fns[key], '__doc__')))
+    print("\nFor more information run %s command --help" % sys.argv[0])
 
 
 def cmd_delete(argv, path_to_tx):


### PR DESCRIPTION
**Problem**
We recently updated the logger formatter to add a prefix in all its output (see [here](https://github.com/transifex/transifex-client/pull/186/files#diff-c6b1be0e6471d27cf8986daf109edf37R16)). This has some side effects like the help text to be displayed like: 
```
tx INFO: Transifex command line client.

tx INFO: Available commands are:
tx INFO:   delete         	Delete an accessible resource or translation in a remote server.
tx INFO:   help           	List all available commands
tx INFO:   init           	Initialize a new transifex project.
tx INFO:   pull           	Pull files from remote server to local repository
tx INFO:   push           	Push local files to remote server
tx INFO:   set            	Add local or remote files under transifex
tx INFO:   status         	Print status of current project
tx INFO:
```
**Solution**
`tx help` and `tx status` output shouldn't be logger output in the first place so we use `print` instead.

@fathineos pls review