### PR TITLE
TX-8917 fix various CLI bugs

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -17,7 +17,7 @@ from collections import namedtuple
 from os.path import dirname
 from sys import modules
 
-from txclib.exceptions import AuthenticationError
+from txclib.exceptions import AuthenticationError, TXConnectionError
 from txclib.project import (Project, DEFAULT_PULL_URL,
                             PULL_MODE_SOURCEASTRANSLATION)
 
@@ -730,6 +730,32 @@ class TestProjectPull(unittest.TestCase):
         project = kwargs['mock_project']
         with self.assertRaises(AuthenticationError):
             project.delete()
+
+    @fixture_mocked_project
+    @patch("txclib.project.logger.error")
+    @patch("txclib.utils.make_request")
+    def test_pull_raises_connection_exception(self, mock_request, mock_logger,
+                                              **kwargs):
+        """Test that all connection errors are properly handled."""
+        project = kwargs["mock_project"]
+        response = 502
+        msg = "Failed with code %d" % response
+        mock_request.side_effect = TXConnectionError(msg, code=response)
+        with self.assertRaises(TXConnectionError):
+            project.pull()
+
+    @fixture_mocked_project
+    @patch("txclib.project.logger.error")
+    @patch("txclib.utils.make_request")
+    def test_push_raises_connection_exception(self, mock_request, mock_logger,
+                                              **kwargs):
+        """Test that all connection errors are properly handled."""
+        project = kwargs["mock_project"]
+        response = 500
+        msg = "Failed with code %d" % response
+        mock_request.side_effect = TXConnectionError(msg, code=response)
+        with self.assertRaises(TXConnectionError):
+            project.push()
 
 
 class TestFormats(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,15 @@ from urllib3.exceptions import SSLError
 from txclib import utils, exceptions
 
 
+# XXX: Taken from https://stackoverflow.com/a/21611963
+def Any():
+    """A method that will match any parameter."""
+    class Any(object):
+        def __eq__(self, *args):
+            return True
+    return Any()
+
+
 class MakeRequestTestCase(unittest.TestCase):
 
     @patch('urllib3.PoolManager')
@@ -177,3 +186,28 @@ class MakeRequestTestCase(unittest.TestCase):
         )
         mock_manager.assert_called_once_with(num_pools=1)
         mock_connection.request.assert_called_once()
+
+    @patch('urllib3.PoolManager')
+    def test_url_format(self, mock_manager):
+        response_mock = MagicMock()
+        response_mock.status = 200
+        response_mock.data = None
+
+        mock_connection = MagicMock()
+        mock_connection.request.return_value = response_mock
+        mock_manager.return_value = mock_connection
+
+        host = 'http://test.com/'
+        url = '/path/to/we/'
+        expected_url = 'http://test.com/path/to/we/'
+        utils.make_request(
+            'GET',
+            host,
+            url,
+            'a_user',
+            'a_pass'
+        )
+        mock_connection.request.assert_called_once_with('GET',
+                                                        expected_url,
+                                                        fields=Any(),
+                                                        headers=Any())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,6 +141,22 @@ class MakeRequestTestCase(unittest.TestCase):
         )
 
     @patch('urllib3.PoolManager')
+    def test_makes_request_connection_error(self, mock_manager):
+        """Tests for common 50X connection errors."""
+        for code in range(500, 506):
+            mock_connection = MagicMock()
+            mock_connection.request.return_value = MagicMock(status=code,
+                                                             data=None)
+            mock_manager.return_value = mock_connection
+
+            host = 'http://whynotestsforthisstuff.com'
+            url = '/my_test_url/'
+            args = ('GET', host, url, 'a_user', 'a_pass',)
+            with self.assertRaises(exceptions.TXConnectionError) as err:
+                utils.make_request(*args)
+            self.assertEqual(err.exception.response_code, code)
+
+    @patch('urllib3.PoolManager')
     def test_makes_request_None(self, mock_manager):
         response_mock = MagicMock()
         response_mock.status = 200

--- a/txclib/cmdline.py
+++ b/txclib/cmdline.py
@@ -112,10 +112,8 @@ def main(argv=None):
         utils.exec_command(cmd, args[1:], path_to_tx)
     except SSLError as e:
         logger.error("SSl error %s" % e)
-        sys.exit(1)
     except utils.UnknownCommandError:
         logger.error("Command %s not found" % cmd)
-        sys.exit(1)
     except AuthenticationError:
         authentication_failed_message = """
 Error: Authentication failed. Please make sure your credentials are valid. You
@@ -130,7 +128,12 @@ visit https://docs.transifex.com/client/client-configuration#-transifexrc.
         else:
             msg = "Unknown error" if not str(e) else str(e)
             logger.error(msg)
-        sys.exit(1)
+    # The else statement will be executed only if the command raised no
+    # exceptions. If an exception was raised, we want to return a non-zero exit
+    # code
+    else:
+        return
+    sys.exit(1)
 
 
 # Run baby :) ... run

--- a/txclib/cmdline.py
+++ b/txclib/cmdline.py
@@ -123,13 +123,13 @@ can update your credentials in the ~/.transifexrc file. For more information,
 visit https://docs.transifex.com/client/client-configuration#-transifexrc.
 """
         logger.error(authentication_failed_message)
-    except Exception:
+    except Exception as e:
         import traceback
         if options.trace:
             traceback.print_exc()
         else:
-            formatted_lines = traceback.format_exc().splitlines()
-            logger.error(formatted_lines[-1])
+            msg = "Unknown error" if not str(e) else str(e)
+            logger.error(msg)
         sys.exit(1)
 
 

--- a/txclib/exceptions.py
+++ b/txclib/exceptions.py
@@ -4,6 +4,8 @@
 Exception classes for the tx client.
 """
 
+from urllib3.connection import ConnectionError
+
 
 class UnInitializedError(Exception):
     """The project directory has not been initialized."""
@@ -37,3 +39,11 @@ class HttpNotAuthorized(Exception):
 
 class AuthenticationError(Exception):
     pass
+
+
+class TXConnectionError(ConnectionError):
+
+    def __init__(self, message, code=None, *args, **kwargs):
+        """Save the response code in the exception."""
+        self.response_code = code
+        super(ConnectionError, self).__init__(message, *args, **kwargs)

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -397,8 +397,8 @@ class Project(object):
                                resource=resource_slug)
             logger.debug("URL data are: %s" % self.url_info)
 
-            stats = self._get_stats_for_resource()
             try:
+                stats = self._get_stats_for_resource()
                 details_response, _ = self.do_url_request('resource_details')
             except Exception as e:
                 if isinstance(e, HttpNotAuthorized):
@@ -410,6 +410,10 @@ class Project(object):
                     continue
                 if isinstance(e, SSLError) or not skip:
                     raise
+                else:
+                    msg = "Skipping resource %s"
+                    logger.warn(msg % resource)
+                    continue
 
             details = utils.parse_json(details_response)
             if details['i18n_type'] in self.SKIP_DECODE_I18N_TYPES:

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -605,13 +605,13 @@ class Project(object):
             stats = self._get_stats_for_resource()
 
             if force and not no_interactive:
-                answer = input("Warning: By using --force, the uploaded "
-                               "files will overwrite remote translations, "
-                               "even if they are newer than your uploaded "
-                               "files.\nAre you sure you want to continue? "
-                               "[y/N]")
+                msg = ("Warning: By using --force, the uploaded files will "
+                       "overwrite remote translations, even if they are newer "
+                       "than your uploaded files.\nAre you sure you want to "
+                       "continue?")
 
-                if answer not in ["", 'Y', 'y', "yes", 'YES']:
+                if not confirm(prompt=msg, default=False):
+                    logger.info("Aborting...")
                     return
 
             if source:

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -17,6 +17,11 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
+try:
+    from urlparse import urljoin  # Python 2
+except ImportError:
+    from urllib.parse import urljoin  # Python 3
+
 from email.parser import Parser
 from urllib3.exceptions import SSLError
 from six.moves import input
@@ -179,7 +184,7 @@ def make_request(method, host, url, username, password, fields=None,
         encoded_request = encode_args(manager.request)
         response = encoded_request(
             method,
-            host + url,
+            urljoin(host, url),
             headers=dict(headers),
             fields=fields
         )

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -23,7 +23,7 @@ from six.moves import input
 from txclib.urls import API_URLS
 from txclib.exceptions import (
     UnknownCommandError, HttpNotFound, HttpNotAuthorized,
-    AuthenticationError
+    AuthenticationError, TXConnectionError,
 )
 from txclib.paths import posix_path, native_path, posix_sep
 from txclib.web import user_agent_identifier, certs_file
@@ -195,8 +195,12 @@ def make_request(method, host, url, username, password, fields=None,
                 raise HttpNotAuthorized(data)
             elif response.status == 404:
                 raise HttpNotFound(data)
+            elif response.status >= 500:
+                msg = "Failed to connect. Server responded with HTTP code {}"
+                raise TXConnectionError(msg.format(response.status),
+                                        code=response.status)
             else:
-                raise Exception(data)
+                raise Exception("Error received from server: {}".format(data))
         return data, charset
     except SSLError:
         logger.error("Invalid SSL certificate")


### PR DESCRIPTION
This fixes the following problems:
* Handle connection errors gracefully and display helpful messages
* Exit with a non-zero code whenever a command fails
* Allow host to have a trailing slash
* Remove code duplicates and correctly interpret user input when the `--force` parameter is specified