### PR TITLE
TX-2663: Correctly distinguish push errors

### DIFF
--- a/txclib/project.py
+++ b/txclib/project.py
@@ -714,9 +714,18 @@ class Project(object):
                         )
                         logger.debug("Translation %s pushed." % remote_lang)
                     except utils.HttpNotFound:
-                        if not source:
-                            logger.error("Resource hasn't been created. "
+                        # If the resource exists, we suppose the language code
+                        # was invalid
+                        if self._resource_exists(stats):
+                            error_msg = ("Error: '%s' is not a valid"
+                                         " language code. Please refer to"
+                                         " https://www.transifex.com/"
+                                         "languages/ for a list of supported"
+                                         " languages in Transifex." % lang)
+                        else:
+                            error_msg = ("Resource hasn't been created. "
                                          "Try pushing source file.")
+                        logger.error(error_msg)
                     except Exception as e:
                         if isinstance(e, SSLError):
                             raise


### PR DESCRIPTION
Provide a correct error message when the user tries to push a language code that is invalid.