### PR TITLE
Branch support

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -717,6 +717,42 @@ class TestProjectPull(unittest.TestCase):
                 Project.AUTHENTICATION_FAILED_MESSAGE)
 
     @fixture_mocked_project
+    @patch('txclib.project.Project.do_url_request')
+    def test_pull_with_branch_pulls_from_right_resource(self, m, **kwargs):
+        m.return_value = ('{"i18n_type": "PO"}', '')
+        project = kwargs['mock_project']
+        project.pull(branch='somebranch')
+        self.assertDictEqual(project.url_info, {
+            'host': 'https://fake.com',
+            'project': 'example',
+            'resource': 'somebranch--enpo'
+        })
+
+    @fixture_mocked_project
+    @patch('txclib.project.Project.do_url_request')
+    def test_push_with_branch_pushes_to_right_resource(self, m, **kwargs):
+        m.return_value = ('{"i18n_type": "PO"}', '')
+        project = kwargs['mock_project']
+        project.push(source=True, branch='somebranch')
+        self.assertDictEqual(project.url_info, {
+            'host': 'https://fake.com',
+            'project': 'example',
+            'resource': 'somebranch--enpo'
+        })
+
+    @fixture_mocked_project
+    @patch('txclib.project.Project.do_url_request')
+    def test_push_with_branch_weird_characters_are_handled(self, m, **kwargs):
+        m.return_value = ('{"i18n_type": "PO"}', '')
+        project = kwargs['mock_project']
+        project.push(source=True, branch='some/b**r:a&n!ch')
+        self.assertDictEqual(project.url_info, {
+            'host': 'https://fake.com',
+            'project': 'example',
+            'resource': 'some-b-r-a-n-ch--enpo'
+        })
+
+    @fixture_mocked_project
     @patch("txclib.project.logger.error")
     def test_push_raises_authentication_exception(self, mock_logger, **kwargs):
         project = kwargs['mock_project']

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -360,12 +360,13 @@ def cmd_push(argv, path_to_tx):
         parser.error("You need to specify at least one of the -s|--source, "
                      "-t|--translations flags with the push command.")
 
+    branch = get_branch_from_options(options, prj.root)
     prj.push(
         force=force_creation, resources=resources, languages=languages,
         skip=skip, source=options.push_source,
         translations=options.push_translations,
         no_interactive=options.no_interactive,
-        xliff=xliff
+        xliff=xliff, branch=branch
     )
     logger.info("Done.")
 
@@ -389,11 +390,12 @@ def cmd_pull(argv, path_to_tx):
 
     # instantiate the project.Project
     prj = project.Project(path_to_tx)
+    branch = get_branch_from_options(options, prj.root)
     prj.pull(
         languages=languages, resources=resources, overwrite=options.overwrite,
         fetchall=options.fetchall, fetchsource=options.fetchsource,
         force=options.force, skip=skip, minimum_perc=minimum_perc,
-        mode=options.mode, pseudo=pseudo, xliff=xliff
+        mode=options.mode, pseudo=pseudo, xliff=xliff, branch=branch
     )
     logger.info("Done.")
 
@@ -605,3 +607,28 @@ def _set_project_option(resource, name, value, path_to_tx, func_name):
     prj = project.Project(path_to_tx)
     getattr(prj, func_name)(resources, value)
     prj.save()
+
+
+def get_branch_from_options(options, project_root):
+    """ Returns the branch name that needs to be used in command
+    based on parser options.
+
+    options: optparse parser options as returned from `parse()`
+    project_root: project root directory
+    """
+    if not options.branch:
+        if options.branchname:
+            logger.error("--branchname options should be used along with "
+                         "the --branch option.")
+            sys.exit(1)
+        return
+
+    if options.branchname:
+        return options.branchname
+
+    branch = utils.get_current_branch(project_root)
+    if not branch:
+        logger.error("You specified the --branch option but current "
+                     "directory does not seem to belong in any git repo.")
+        sys.exit(1)
+    return branch

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -616,14 +616,14 @@ def get_branch_from_options(options, project_root):
     options: optparse parser options as returned from `parse()`
     project_root: project root directory
     """
-    if not options.branch:
-        if options.branchname:
-            logger.error("--branchname options should be used along with "
-                         "the --branch option.")
-            sys.exit(1)
+    if not options.branch and not options.branchname:
         return
 
     if options.branchname:
+        if not options.branch:
+            logger.error("--branchname options should be used along with "
+                         "the --branch option.")
+            sys.exit(1)
         return options.branchname
 
     branch = utils.get_current_branch(project_root)

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -140,6 +140,16 @@ def pull_parser():
             "'reviewed'). See http://bit.ly/pullmode for available values."
         )
     )
+    parser.add_option(
+        "-b", "--branch", action="store_true", dest="branch",
+        default=False,
+        help=("Push to a specific branch. Default is current"
+              "branch if exists.")
+    )
+    parser.add_option(
+        "--branchname", action="store", dest="branchname",
+        help=("Specify the branch name to which we are going to push.")
+    )
     parser.add_option("-x", "--xliff", action="store_true", dest="xliff",
                       default=False, help="Apply this option to download "
                       "file as xliff.")
@@ -184,6 +194,17 @@ def push_parser():
     parser.add_option("-x", "--xliff", action="store_true", dest="xliff",
                       default=False, help="Apply this option to upload "
                       "file as xliff.")
+    parser.add_option(
+        "-b", "--branch", action="store_true", dest="branch",
+        default=False,
+        help=("Pull for a specific branch. Default is current"
+              "branch if exists.")
+    )
+    parser.add_option(
+        "--branchname", action="store", dest="branchname",
+        help=("Specify the branch name for which the resources "
+              "we are going to pull.")
+    )
     return parser
 
 

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -540,7 +540,7 @@ def get_current_branch(root_dir):
     root.
     Return current branch if .git exists else None
     """
-    git_dir = None
+    found, git_dir = None, None
     cwd = os.getcwd()
     while root_dir in cwd:
         git_dir = os.path.join(cwd, '.git')
@@ -551,5 +551,7 @@ def get_current_branch(root_dir):
 
     if found:
         with open(os.path.join(git_dir, 'HEAD')) as f:
-            ref = f.read().replace('\n', '')
-            return ref.split('/')[-1]
+            ref = f.read()
+            m = re.match('ref: refs/heads/(.+?)\s+$', ref)
+            if m:
+                return m.group(1)

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -532,3 +532,24 @@ def get_api_domains(path_to_tx, host):
     except (ProjectNotInit, configparser.NoOptionError,
             configparser.NoSectionError):
         return DEFAULT_HOSTNAMES
+
+
+def get_current_branch(root_dir):
+    """Searches for a .git directory starting from the
+    current working directory and up until the project
+    root.
+    Return current branch if .git exists else None
+    """
+    git_dir = None
+    cwd = os.getcwd()
+    while root_dir in cwd:
+        git_dir = os.path.join(cwd, '.git')
+        if os.path.isdir(git_dir):
+            found = True
+            break
+        cwd = os.path.dirname(cwd)
+
+    if found:
+        with open(os.path.join(git_dir, 'HEAD')) as f:
+            ref = f.read().replace('\n', '')
+            return ref.split('/')[-1]


### PR DESCRIPTION
Summary
---------
Adds basic support for branch in Transifex Client. `tx pull` and `tx push` now accepts two extra arguments `--branch` and `--branchname` in order to push/pull different version of the configured resources. If only the `--branch` option is pass the client tries to detect the current git branch from the filesystem and throughs an error if not under a git repo. If branchname is passed then takes precedence over the current git branch if it exists.
When the branch is specified, for each resource specified a new resource is created on Transifex with slug `<branchname>--<resource_slug>`. Translations or source content are then pushed and pulled from the resource matching that pattern.