### PR TITLE
Backwards compatibility, update on supported python versions

### DIFF
--- a/contrib/tx_commands.sh
+++ b/contrib/tx_commands.sh
@@ -12,7 +12,7 @@ git clone https://github.com/transifex/txci.git
 cd txci
 rm -rf .tx
 $TX init --host="https://www.transifex.com" --token=$TRANSIFEX_TOKEN --skipsetup --no-interactive
-$TX set auto-local -r txci.$BRANCH\_$TRANSIFEX_USER\_$RANDOM -s en 'locale/<lang>/LC_MESSAGES/django.po' -t PO --execute
+$TX config mapping -r txci.$BRANCH\_$TRANSIFEX_USER\_$RANDOM -s en 'locale/<lang>/LC_MESSAGES/django.po' -t PO --execute
 
 # push/pull without XLIFF
 echo "Pushing Source..."

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     license="GPLv2",
     dependency_links=[],
     setup_requires=[],
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.6',
     install_requires=get_file_content('requirements.txt').splitlines(),
     tests_require=["mock"],
     data_files=[],
@@ -35,9 +36,7 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.5',
     ],
 )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -367,9 +367,8 @@ class TestSetCommand(unittest.TestCase):
             cmd_set(args, self.path_to_tx)
 
         with self.assertRaises(SystemExit):
-            args = ["bulk", "-p", "test-project", "--source-file-dir",
-                    "translations", "--source-language", "en", "--t", "TXT",
-                    "--file-extension", ".txt"]
+            args = ["bulk", "-p", "test-project", "--source-language",
+                    "en", "--t", "TXT", "--file-extension", ".txt"]
             cmd_set(args, self.path_to_tx)
 
     def test_bulk(self):
@@ -380,7 +379,7 @@ class TestSetCommand(unittest.TestCase):
                     "source_lang = en\ntype = TXT\n\n")
         args = ["bulk", "-p", "test-project", "--source-file-dir",
                 "translations", "--source-language", "en", "-t", "TXT",
-                "--file-extension", ".txt", "--execute",
+                "--file-extension", ".txt", "--execute", "--expression",
                 "translations/<lang>/{filepath}/{filename}{extension}"]
         cmd_set(args, self.path_to_tx)
         with open(self.config_file) as config:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,8 +5,9 @@ import sys
 from StringIO import StringIO
 from mock import patch, MagicMock, call
 from txclib.commands import _set_source_file, _set_translation, cmd_pull, \
-    cmd_init, cmd_set, cmd_status, cmd_help, UnInitializedError
+    cmd_init, cmd_config, cmd_status, cmd_help, UnInitializedError
 from txclib.cmdline import main
+from txclib.parsers import MAPPING, MAPPINGREMOTE, MAPPINGBULK
 
 
 class TestCommands(unittest.TestCase):
@@ -77,7 +78,7 @@ class TestInitCommand(unittest.TestCase):
         argv = []
         config_text = "[main]\nhost = https://www.transifex.com\n\n"
         with patch('txclib.commands.project.Project') as project_mock:
-            with patch('txclib.commands.cmd_set') as set_mock:
+            with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 project_mock.assert_called()
                 set_mock.assert_called_once_with([], os.getcwd())
@@ -88,7 +89,7 @@ class TestInitCommand(unittest.TestCase):
     def test_init_skipsetup(self):
         argv = ['--skipsetup']
         with patch('txclib.commands.project.Project') as project_mock:
-            with patch('txclib.commands.cmd_set') as set_mock:
+            with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 project_mock.assert_called()
                 self.assertEqual(set_mock.call_count, 0)
@@ -114,7 +115,7 @@ class TestInitCommand(unittest.TestCase):
         argv = []
         confirm_mock.return_value = True
         with patch('txclib.commands.project.Project') as project_mock:
-            with patch('txclib.commands.cmd_set') as set_mock:
+            with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 project_mock.assert_called()
                 set_mock.assert_called()
@@ -125,7 +126,7 @@ class TestInitCommand(unittest.TestCase):
         os.mkdir('./.tx')
         argv = ['--force-save']
         with patch('txclib.commands.project.Project') as project_mock:
-            with patch('txclib.commands.cmd_set') as set_mock:
+            with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 project_mock.assert_called()
                 set_mock.assert_called()
@@ -183,7 +184,7 @@ class TestPullCommand(unittest.TestCase):
         pr_instance.pull.assert_has_calls([pull_call])
 
 
-class TestSetCommand(unittest.TestCase):
+class TestConfigCommand(unittest.TestCase):
 
     def setUp(self):
         self.curr_dir = os.getcwd()
@@ -196,28 +197,28 @@ class TestSetCommand(unittest.TestCase):
     def tearDown(self, *args, **kwargs):
         shutil.rmtree('.tx', ignore_errors=False, onerror=None)
         os.chdir(self.curr_dir)
-        super(TestSetCommand, self).tearDown(*args, **kwargs)
+        super(TestConfigCommand, self).tearDown(*args, **kwargs)
 
     def test_bare_set_too_few_arguments(self):
         with self.assertRaises(SystemExit):
             args = ["-r", "project1.resource1"]
-            cmd_set(args, None)
+            cmd_config(args, None)
 
     def test_bare_set_source_no_file(self):
         with self.assertRaises(SystemExit):
             args = ["-r", "project1.resource1", '--is-source', '-l', 'en']
-            cmd_set(args, None)
+            cmd_config(args, None)
 
         with self.assertRaises(Exception):
             args = ['-r', 'project1.resource1', '--source', '-l', 'en',
                     'noexistent-file.txt']
-            cmd_set(args, self.path_to_tx)
+            cmd_config(args, self.path_to_tx)
 
     def test_bare_set_source_file(self):
         expected = ("[main]\nhost = https://foo.var\n\n[project1.resource1]\n"
                     "source_file = test.txt\nsource_lang = en\n\n")
         args = ["-r", "project1.resource1", '--source', '-l', 'en', 'test.txt']
-        cmd_set(args, self.path_to_tx)
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 
@@ -226,21 +227,21 @@ class TestSetCommand(unittest.TestCase):
                     "source_file = test.txt\nsource_lang = en\n"
                     "trans.de = translations/de.txt\n\n")
         args = ["-r", "project1.resource1", '-l', 'de', 'translations/de.txt']
-        cmd_set(args, self.path_to_tx)
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 
     def test_auto_locale_no_expression(self):
         with self.assertRaises(SystemExit):
-            args = ["auto-local", "-r", "project1.resource1",
+            args = [MAPPING, "-r", "project1.resource1",
                     '--source-language', 'en']
-            cmd_set(args, self.path_to_tx)
+            cmd_config(args, self.path_to_tx)
 
     def test_auto_locale(self):
         expected = "[main]\nhost = https://foo.var\n"
-        args = ["auto-local", "-r", "project1.resource1", '--source-language',
+        args = [MAPPING, "-r", "project1.resource1", '--source-language',
                 'en', 'translations/<lang>/test.txt']
-        cmd_set(args, self.path_to_tx)
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 
@@ -253,7 +254,7 @@ class TestSetCommand(unittest.TestCase):
         args = ["--auto-local", "-r", "project1.resource1",
                 '--source-language', 'en', '--execute',
                 'translations/<lang>/test.txt']
-        cmd_set(args, self.path_to_tx)
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 
@@ -263,22 +264,22 @@ class TestSetCommand(unittest.TestCase):
                     "source_file = translations/en/test.txt\n"
                     "source_lang = en\n\n")
 
-        args = ["auto-local", "-r", "project1.resource1", '--source-language',
+        args = [MAPPING, "-r", "project1.resource1", '--source-language',
                 'en', '--execute', 'translations/<lang>/test.txt']
-        cmd_set(args, self.path_to_tx)
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 
     def test_auto_remote_invalid_url(self):
         # no project_url
-        args = ["auto-remote"]
+        args = [MAPPINGREMOTE]
         with self.assertRaises(SystemExit):
-            cmd_set(args, self.path_to_tx)
+            cmd_config(args, self.path_to_tx)
 
         # invalid project_url
-        args = ["auto-remote", "http://some.random.url/"]
+        args = [MAPPINGREMOTE, "http://some.random.url/"]
         with self.assertRaises(Exception):
-            cmd_set(args, self.path_to_tx)
+            cmd_config(args, self.path_to_tx)
 
     @patch('txclib.utils.get_details')
     @patch('txclib.project.Project._extension_for')
@@ -313,8 +314,8 @@ class TestSetCommand(unittest.TestCase):
                 'slug': 'resource_2',
             }
         ]
-        args = ["auto-remote", "https://www.transifex.com/test-org/proj/"]
-        cmd_set(args, self.path_to_tx)
+        args = [MAPPINGREMOTE, "https://www.transifex.com/test-org/proj/"]
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 
@@ -353,23 +354,23 @@ class TestSetCommand(unittest.TestCase):
             }
         ]
         args = ["--auto-remote", "https://www.transifex.com/test-org/proj/"]
-        cmd_set(args, self.path_to_tx)
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 
     def test_bulk_missing_options(self):
         with self.assertRaises(SystemExit):
-            args = ["bulk"]
-            cmd_set(args, self.path_to_tx)
+            args = [MAPPINGBULK]
+            cmd_config(args, self.path_to_tx)
 
         with self.assertRaises(SystemExit):
-            args = ["bulk", "-p", "test-project"]
-            cmd_set(args, self.path_to_tx)
+            args = [MAPPINGBULK, "-p", "test-project"]
+            cmd_config(args, self.path_to_tx)
 
         with self.assertRaises(SystemExit):
-            args = ["bulk", "-p", "test-project", "--source-language",
+            args = [MAPPINGBULK, "-p", "test-project", "--source-language",
                     "en", "--t", "TXT", "--file-extension", ".txt"]
-            cmd_set(args, self.path_to_tx)
+            cmd_config(args, self.path_to_tx)
 
     def test_bulk(self):
         expected = ("[main]\nhost = https://foo.var\n\n"
@@ -377,11 +378,11 @@ class TestSetCommand(unittest.TestCase):
                     "file_filter = translations/<lang>/en/test.txt\n"
                     "source_file = translations/en/test.txt\n"
                     "source_lang = en\ntype = TXT\n\n")
-        args = ["bulk", "-p", "test-project", "--source-file-dir",
+        args = [MAPPINGBULK, "-p", "test-project", "--source-file-dir",
                 "translations", "--source-language", "en", "-t", "TXT",
                 "--file-extension", ".txt", "--execute", "--expression",
                 "translations/<lang>/{filepath}/{filename}{extension}"]
-        cmd_set(args, self.path_to_tx)
+        cmd_config(args, self.path_to_tx)
         with open(self.config_file) as config:
             self.assertEqual(config.read(), expected)
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -123,7 +123,7 @@ class WizardCase(unittest.TestCase):
             [
                 {
                     "name": "project 1",
-                    "source_language_code": "en",
+                    "source_language": {"code": "en", "name": "English"},
                     "slug": "project-1",
                     "archived": False
                 }

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -27,7 +27,8 @@ from txclib import utils, project
 from txclib.config import OrderedRawConfigParser
 from txclib.exceptions import UnInitializedError
 from txclib.parsers import delete_parser, help_parser, parse_csv_option, \
-    status_parser, pull_parser, set_parser, push_parser, init_parser
+    status_parser, pull_parser, set_parser, push_parser, init_parser, \
+    AUTOLOCAL, AUTOREMOTE, BULK
 from txclib.paths import posix_path
 from txclib.log import logger
 from txclib.wizard import Wizard
@@ -97,7 +98,7 @@ def cmd_set(argv, path_to_tx):
         # subcommand there are some default options that need to be set
         default_options = {
             'execute': True,
-            'subcommand': 'auto-local',
+            'subcommand': AUTOLOCAL,
             'minimum_perc': 0,
             'mode': None,
         }
@@ -112,6 +113,15 @@ def cmd_set(argv, path_to_tx):
             print("\n")
             sys.exit(1)
     else:
+        # hack to support backwards compatibility
+        # for --auto-local and --auto-remote options
+        if '--auto-local' in argv:
+            argv.pop(argv.index('--auto-local'))
+            argv.insert(0, AUTOLOCAL)
+        if '--auto-remote' in argv:
+            argv.pop(argv.index('--auto-remote'))
+            argv.insert(0, AUTOREMOTE)
+
         is_subcommand = argv[0] in SET_SUBCOMMANDS.keys()
         parser = set_parser(subparser=is_subcommand)
         options = parser.parse_args(argv)
@@ -300,7 +310,7 @@ def _auto_local(path_to_tx, resource, source_language, expression,
             prj.config.get("%s" % resource, "source_file")
         except configparser.NoSectionError:
             raise Exception("No resource with slug \"%s\" was found.\nRun "
-                            "'tx set --auto-local -r %s \"expression\"' to "
+                            "'tx set auto-local -r %s \"expression\"' to "
                             "do the initial configuration." % resource)
 
     # Now let's handle the translation files.
@@ -670,7 +680,7 @@ def get_branch_from_options(options, project_root):
 
 
 SET_SUBCOMMANDS = {
-    'auto-local': subcommand_autolocal,
-    'auto-remote': subcommand_autoremote,
-    'bulk': subcommand_bulk
+    AUTOLOCAL: subcommand_autolocal,
+    AUTOREMOTE: subcommand_autoremote,
+    BULK: subcommand_bulk
 }

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -325,12 +325,12 @@ def set_parser(subparser=False):
         "files and projects for multiple resources at once, using local files."
     bulk_epilog = "\nExamples:\n"\
         "To set a series of HTML source files that reside inside locale/:\n"\
-        " $ %(prog)s -p project 'expression' --source-language en --type HTML"\
+        " $ %(prog)s -p project --source-language en --type HTML"\
         " -f '.html' --source-file-dir locale\n\n"\
         "To set a series of KEYVAlUEJSON source files that reside " \
         "inside locale/ but exclude files in locale/es/ and locale/jp/:\n"\
-        " $ %(prog)s -p project 'expr' --source-language en " \
-        "--type KEYVAlUEJSON -f '.json' -d locale -i es -i jp\n\n"
+        " $ %(prog)s -p project --source-language en --type KEYVAlUEJSON " \
+        "-f '.json' --source-file-dir locale -i es -i jp\n\n"
 
     main_parser = set_main_parser()
     extra_parser = set_extra_parser()
@@ -425,11 +425,11 @@ def set_parser(subparser=False):
         help="Directory to ignore while looking for source "
              "files. Can be called multiple times. Example: `-i es -i fr`.'.")
     auto_bulk_parser.add_argument(
-        "expression", action="store",
-        help="A path expression pointing to the location where translation "
-             "files for the associated source file are/will be saved. Use "
-             "<lang> as a wildcard for the language code, "
-             "e.g. translations/<lang>/test.txt."
+        "--expression", action="store",
+        default='locale/<lang>/{filepath}/{filename}{extension}',
+        help="Expression defining where translation files should be save. "
+             "Default value is: "
+             "'locale/<lang>/{filepath}/{filename}{extension}'"
     )
     auto_bulk_parser.add_argument(
         "--execute", action="store_true", dest="execute", default=False,

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -180,7 +180,8 @@ def pull_parser():
     parser.add_argument(
         "--mode", action="store", dest="mode", help=(
             "Specify the mode of the translation file to pull (e.g. "
-            "'reviewed'). See http://bit.ly/pullmode for available values."
+            "'reviewed'). See https://docs.transifex.com/client/pull/ "
+            "for available values."
         )
     )
     parser.add_argument(
@@ -283,8 +284,8 @@ def set_extra_parser():
     extra_parser.add_argument(
         "--mode", action="store", dest="mode", help=(
             "Specify the mode of the translation file to pull (e.g. "
-            "'reviewed'). See http://bit.ly/pullmode for the "
-            "available values."
+            "'reviewed'). See https://docs.transifex.com/client/pull/ "
+            "for the available values."
         )
     )
     return extra_parser

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -7,6 +7,9 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from txclib.utils import get_version
 
 
+AUTOLOCAL, AUTOREMOTE, BULK = 'auto-local', 'auto-remote', 'bulk'
+
+
 def tx_main_parser():
     description = "This is the Transifex command line client which"\
                   " allows you to manage your translations locally and sync"\
@@ -261,6 +264,12 @@ def set_main_parser():
                                    "list of available i18n types, see "
                                    "http://docs.transifex.com/formats/"
                                    ))
+    main_parser.add_argument("--auto-local", action="store_true",
+                             dest="local", default=False,
+                             help="Alias of auto-local subcommands")
+    main_parser.add_argument("--auto-remote", action="store_true",
+                             dest="local", default=False,
+                             help="Alias of auto-remote subcommands")
     return main_parser
 
 
@@ -287,14 +296,16 @@ def set_parser(subparser=False):
         "files and projects either\nusing local files or using files from a "\
         "remote Transifex server."
     epilog = "\nSubcommands:\n"\
-        "    auto-local\n"\
-        "    auto-remote\n"\
-        "    bulk\n\n"\
+        "    {autolocal}\n"\
+        "    {autoremote}\n"\
+        "    {bulk}\n\n"\
         "Examples:\n"\
         "To set the source file:\n\
         $ tx set -r project.resource --source -l en <file>\n\n"\
         "To set a single translation file:\n\
-        $ tx set -r project.resource -l de <file>\n"
+        $ tx set -r project.resource -l de <file>\n".format(
+        autolocal=AUTOLOCAL, autoremote=AUTOREMOTE, bulk=BULK
+    )
     auto_local_description = "This command can be used to create a mapping "\
                              "for a local file using the path expression "\
                              "argument to automatically detect source and "\
@@ -344,7 +355,7 @@ def set_parser(subparser=False):
     # auto-local subparser
     subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
     auto_local_parser = subparsers.add_parser(
-        "auto-local", prog="tx set auto-local",
+        AUTOLOCAL, prog="tx set {}".format(AUTOLOCAL),
         parents=[main_parser, extra_parser], epilog=auto_local_epilog,
         description=auto_local_description,
         formatter_class=RawDescriptionHelpFormatter,
@@ -369,8 +380,8 @@ def set_parser(subparser=False):
 
     # auto-remote subparser
     auto_remote_parser = subparsers.add_parser(
-        "auto-remote", parents=[extra_parser], prog="tx set auto-remote",
-        description=auto_remote_description,
+        AUTOREMOTE, prog="tx set {}".format(AUTOREMOTE),
+        parents=[extra_parser], description=auto_remote_description,
         epilog=auto_remote_epilog, formatter_class=RawDescriptionHelpFormatter,
         help="Use to configure remote files from Transifex server."
     )
@@ -378,7 +389,7 @@ def set_parser(subparser=False):
                                     help="Url of Transifex project.")
     # auto-bulk subparser
     auto_bulk_parser = subparsers.add_parser(
-        "bulk", parents=[extra_parser], prog="tx set bulk",
+        BULK, parents=[extra_parser], prog="tx set {}".format(BULK),
         description=bulk_description, epilog=bulk_epilog,
         help="Use to auto configure multiple local files.",
         formatter_class=RawDescriptionHelpFormatter

--- a/txclib/wizard.py
+++ b/txclib/wizard.py
@@ -175,7 +175,7 @@ class Wizard(object):
             else:
                 project = [p for p in projects
                            if p['slug'] == project_slug][0]
-                source_language = project['source_language_code']
+                source_language = project['source_language']['code']
 
         resource_slug = slugify(os.path.basename(source_file))
         resource = '{}.{}'.format(project_slug, resource_slug)


### PR DESCRIPTION
* Make auto-local, auto-remote backwards compatible
* Limit supported Python versions 2.7, 3.5
* Update source_language field to reflect change in the API
* Make expression argument for bulk subcommand optional with a default value