### PR TITLE
Fix some Python 3 compatibility issues

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,7 +2,10 @@ import os
 import shutil
 import unittest
 import sys
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 from mock import patch, MagicMock, call
 from txclib.commands import _set_source_file, _set_translation, cmd_pull, \
     cmd_init, cmd_config, cmd_status, cmd_help, UnInitializedError

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,py35}-{vanilla,pyopenssl}
+envlist = py{27,35}-{vanilla,pyopenssl}
 
 [testenv]
 deps =

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -21,9 +21,10 @@ def tx_main_parser():
                   " `%(prog)s help command`"
     version = get_version()
     parser = ArgumentParser(
-        version=version, description=description, add_help=False
+        description=description, add_help=False
     )
     # parser.disable_interspersed_args()
+    parser.add_argument('--version', action='version', version=version)
     parser.add_argument(
         "-d", "--debug", action="store_true", dest="debug",
         default=False, help=("enable debug messages")

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -1244,8 +1244,8 @@ class Project(object):
             return res[i18n_type]['file-extensions'].split(',')[0]
         except Exception as e:
             logger.warning(
-                "The file extension for i18n_type %s is not found."
-                % e.message)
+                "The file extension for i18n_type %s is not found." % str(e)
+            )
             return ''
 
     def _resource_exists(self, stats):


### PR DESCRIPTION
* Import `StringIO` from `io` module in Python 3
* Fix typo in tox.ini that was causing tests to run in Python 2.7
* Don't use `Exception.message` as it is not supported in Python 3
* Fix incompatible syntax in ArgumentParser parameters

Fixes #207 