### PR TITLE
Document running tests.

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -1,3 +1,16 @@
+Testing
+=======
+
+To run tests, install `mock` and `pytest`::
+
+	$ virtualenv venv
+	$ source venv/bin/activate
+	$ pip install -e .[test]
+	$ pip install mock  # strange, setup.py has tests_require=["mock"]
+	$ pip install pytest
+	$ py.test tests/
+
+
 Releasing
 =========
 


### PR DESCRIPTION
I spent some time figuring this out, and thought i'd document it.

I noted that `mock` isn't installed by running `pip install -e .[test]`. I also tried replacing `tests_require=["mock"]` with `test_requires=["mock"]` in `setup.py`, which did not help. I saw this in a python2.7 virtualenv.