### PR TITLE
Python 3.6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Build transifex-client for Windows
 
 2.  Download and install [Python](https://www.python.org/downloads/windows/).
 
-    At this step choose right version of python: 2 or 3 and x86 or x86-64 instruction set.
+    At this step choose the right version of python (2.7, 3.5 or 3.6) and x86 or x86-64 instruction set.
 
     Make sure pip marked for installation(default for latest installers).
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license="GPLv2",
     dependency_links=[],
     setup_requires=[],
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.6',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     install_requires=get_file_content('requirements.txt').splitlines(),
     tests_require=["mock"],
     data_files=[],
@@ -38,5 +38,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
As requested in #208, here is a PR to start supporting python3.6. 

- Make setup.py stop disallowing python3.6 and higher. The tests still pass under python3.6

Should we maybe update `circle.yml` and `tox.ini` as well?

I've marked the PR as editable by maintainers, so feel free to add any python3.6 compat requirements you see fit.