### PR TITLE
Add `--expression` as an argument for `tx config mapping`, so the `tx config` commands are consistent

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     from io import StringIO
 from mock import patch, MagicMock, call
+from six import assertRaisesRegex
 from txclib.commands import _set_source_file, _set_translation, cmd_pull, \
     cmd_init, cmd_config, cmd_status, cmd_help, UnInitializedError
 from txclib.cmdline import main
@@ -239,7 +240,8 @@ class TestConfigCommand(unittest.TestCase):
             self.assertEqual(config.read(), expected)
 
     def test_auto_locale_no_expression(self):
-        with self.assertRaises(SystemExit):
+        error_msg = "You need to specify an expression"
+        with assertRaisesRegex(self, Exception, error_msg):
             args = [MAPPING, "-r", "project1.resource1",
                     '--source-language', 'en']
             cmd_config(args, self.path_to_tx)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -197,7 +197,9 @@ class TestConfigCommand(unittest.TestCase):
         os.mkdir('.tx')
         self.path_to_tx = os.getcwd()
         self.config_file = '.tx/config'
-        open(self.config_file, "w").write('[main]\nhost = https://foo.var\n')
+        self.config_fd = open(self.config_file, "w")
+        self.config_fd.write("[main]\nhost = https://foo.var\n")
+        self.config_fd.close()
 
     def tearDown(self, *args, **kwargs):
         shutil.rmtree('.tx', ignore_errors=False, onerror=None)

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -101,13 +101,14 @@ def cmd_config(argv, path_to_tx, is_legacy=False):
     """Add local or remote files under transifex"""
     from_wizard = False
     if len(argv) == 0:
-        # since interactive wizard should be equivalant to auto-local
+        # since interactive wizard should be equivalent to auto-local
         # subcommand there are some default options that need to be set
         default_options = {
             'execute': True,
             'subcommand': MAPPING,
             'minimum_perc': 0,
             'mode': None,
+            'expression_legacy': None,
         }
         try:
             # Run the wizard and configure parse with the wizard inputs
@@ -189,7 +190,7 @@ def bare_set(path_to_tx, options):
 
 
 def subcommand_mapping(path_to_tx, options, from_wizard=False):
-    expression = options.expression
+    expression = options.expression or options.expression_legacy
     _auto_local(path_to_tx, options.resource,
                 source_language=options.source_language,
                 expression=expression, source_file=options.source_file,
@@ -274,6 +275,9 @@ def _auto_local(path_to_tx, resource, source_language, expression,
     curpath = os.path.abspath(os.curdir)
 
     # Force expr to be a valid regex expr (escaped) but keep <lang> intact
+    if not expression:
+        raise Exception("You need to specify an expression to define where "
+                        "translation files should be saved.")
     expr_re = utils.regex_from_filefilter(expression, curpath)
     expr_rec = re.compile(expr_re)
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -392,11 +392,14 @@ def set_parser(subparser=False, is_legacy=False):
         "--execute", action="store_true", dest="execute", default=False,
         help="Execute commands.")
     auto_local_parser.add_argument(
-        "expression", action="store",
-        help="A path expression pointing to the location where translation "
-             "files for the associated source file are/will be saved. Use "
-             "<lang> as a wildcard for the language code, "
-             "e.g. translations/<lang>/test.txt."
+        "--expression", action="store",
+        help=("Expression defining where translation files should be saved. "
+              "Default value is: "
+              "'locale/<lang>/{filepath}/{filename}{extension}'")
+    )
+    auto_local_parser.add_argument(
+        "expression_legacy", action="store", nargs="?",
+        help="DEPRECATED: Use --expression instead."
     )
 
     # auto-remote subparser


### PR DESCRIPTION
Deprecate the positional argument `expression` for the `tx config mapping` command in favour of `--expression` so all sub-commands are consistent.