### PR TITLE
 Use TX_TOKEN env var for API token

### DIFF
--- a/contrib/tx_commands.sh
+++ b/contrib/tx_commands.sh
@@ -6,12 +6,14 @@ fi
 # Exit on fail
 set -e
 
+export TX_TOKEN=$TRANSIFEX_TOKEN
+
 # Set up repo, tx config
 rm -rf txci
 git clone https://github.com/transifex/txci.git
 cd txci
 rm -rf .tx
-$TX init --host="https://www.transifex.com" --token=$TRANSIFEX_TOKEN --skipsetup --no-interactive
+$TX init --host="https://www.transifex.com" --skipsetup --no-interactive
 $TX config mapping -r txci.$BRANCH\_$TRANSIFEX_USER\_$RANDOM -s en 'locale/<lang>/LC_MESSAGES/django.po' -t PO --execute
 
 # push/pull without XLIFF

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -85,7 +85,6 @@ class TestInitCommand(unittest.TestCase):
         with patch('txclib.commands.project.Project') as project_mock:
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
-                project_mock.assert_called()
                 set_mock.assert_called_once_with([], os.getcwd())
         self.assertTrue(os.path.exists('./.tx'))
         self.assertTrue(os.path.exists('./.tx/config'))
@@ -96,7 +95,6 @@ class TestInitCommand(unittest.TestCase):
         with patch('txclib.commands.project.Project') as project_mock:
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
-                project_mock.assert_called()
                 self.assertEqual(set_mock.call_count, 0)
         self.assertTrue(os.path.exists('./.tx'))
         self.assertTrue(os.path.exists('./.tx/config'))
@@ -122,7 +120,6 @@ class TestInitCommand(unittest.TestCase):
         with patch('txclib.commands.project.Project') as project_mock:
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
-                project_mock.assert_called()
                 set_mock.assert_called()
         self.assertTrue(os.path.exists('./.tx'))
         self.assertEqual(confirm_mock.call_count, 1)
@@ -133,7 +130,6 @@ class TestInitCommand(unittest.TestCase):
         with patch('txclib.commands.project.Project') as project_mock:
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
-                project_mock.assert_called()
                 set_mock.assert_called()
         self.assertTrue(os.path.exists('./.tx'))
         self.assertTrue(os.path.exists('./.tx/config'))

--- a/txclib/cmdline.py
+++ b/txclib/cmdline.py
@@ -69,14 +69,14 @@ def main(argv=None):
     try:
         utils.exec_command(cmd, rest, path_to_tx)
     except SSLError as e:
-        logger.error("SSl error %s" % e)
+        logger.error("SSL error %s" % e)
     except utils.UnknownCommandError:
         logger.error("Command %s not found" % cmd)
     except AuthenticationError:
         authentication_failed_message = """
-Error: Authentication failed. Please make sure your credentials are valid. You
-can update your credentials in the ~/.transifexrc file. For more information,
-visit https://docs.transifex.com/client/client-configuration#-transifexrc.
+Error: Authentication failed. Please make sure your credentials are valid.
+For more information, visit:
+https://docs.transifex.com/client/client-configuration#-transifexrc.
 """
         logger.error(authentication_failed_message)
     except Exception as e:

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -75,17 +75,15 @@ def cmd_init(argv, path_to_tx):
         config.write(fh)
         fh.close()
 
-    prj = project.Project(path_to_tx)
-    prj.getset_host_credentials(transifex_host, username=options.user,
-                                password=options.password,
-                                token=options.token, force=options.save,
-                                no_interactive=options.no_interactive)
-    prj.save()
-
     if not options.skipsetup and not options.no_interactive:
         logger.info(messages.running_tx_set)
         cmd_config([], path_to_tx)
     else:
+        prj = project.Project(path_to_tx)
+        prj.getset_host_credentials(transifex_host, username=options.user,
+                                    password=options.password,
+                                    token=options.token, force=options.save,
+                                    no_interactive=options.no_interactive)
         logger.info("Done.")
 
 


### PR DESCRIPTION
1. don't write cleartext passwords to ~/.transifexrc. 
2. Existing configs with passwords are treated like before.
3. use TX_TOKEN environment variable as the API token if not otherwise
   provided.

Example:

```
$ export TX_TOKEN=1/deadbeef...
$ tx init

 _____                    _  __
|_   _| __ __ _ _ __  ___(_)/ _| _____  __
  | || '__/ _` | '_ \/ __| | |_ / _ \ \/ /
  | || | | (_| | | | \__ \ |  _|  __/>  <
  |_||_|  \__,_|_| |_|___/_|_|  \___/_/\_\

Welcome to the Transifex Client! Please follow the instructions to
initialize your project.

tx INFO: Creating .tx folder...
<snip>
$ tx push --source
tx INFO: Pushing resource testproject.testresource-txt
tx INFO: Updating /Users/myself/.transifexrc file...
tx INFO: Pushing source file (testresource.txt)
tx INFO: Updating /Users/myself/.transifexrc file...
tx INFO: Done.
$
```

Upside (or downside?): without editing the config file himself, the user cannot do the ill-advised thing and set his password in the config file.
Downside: there is no option to pass the token on the command line (yet).