### PR TITLE
Env token along with token argument

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "pip install --disable-pip-version-check --user --upgrade pip==9.0.3"
   - "pip install pyinstaller"
 
   # Set up the project in develop mode. If some dependencies contain

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -82,7 +82,7 @@ class TestInitCommand(unittest.TestCase):
     def test_init(self):
         argv = []
         config_text = "[main]\nhost = https://www.transifex.com\n\n"
-        with patch('txclib.commands.project.Project') as project_mock:
+        with patch('txclib.commands.project.Project'):
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 set_mock.assert_called_once_with([], os.getcwd())
@@ -92,7 +92,7 @@ class TestInitCommand(unittest.TestCase):
 
     def test_init_skipsetup(self):
         argv = ['--skipsetup']
-        with patch('txclib.commands.project.Project') as project_mock:
+        with patch('txclib.commands.project.Project'):
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 self.assertEqual(set_mock.call_count, 0)
@@ -117,7 +117,7 @@ class TestInitCommand(unittest.TestCase):
         open('./.tx/config', 'a').close()
         argv = []
         confirm_mock.return_value = True
-        with patch('txclib.commands.project.Project') as project_mock:
+        with patch('txclib.commands.project.Project'):
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 set_mock.assert_called()
@@ -127,7 +127,7 @@ class TestInitCommand(unittest.TestCase):
     def test_init_force_save(self):
         os.mkdir('./.tx')
         argv = ['--force-save']
-        with patch('txclib.commands.project.Project') as project_mock:
+        with patch('txclib.commands.project.Project'):
             with patch('txclib.commands.cmd_config') as set_mock:
                 cmd_init(argv, '')
                 set_mock.assert_called()

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -84,6 +84,7 @@ def cmd_init(argv, path_to_tx):
                                     password=options.password,
                                     token=options.token, force=options.save,
                                     no_interactive=options.no_interactive)
+        prj.save()
         logger.info("Done.")
 
 

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -42,6 +42,7 @@ DEFAULT_PULL_URL = 'pull_file'
 PULL_MODE_URL_NAME = "pull_{mode}_file"
 
 DEFAULT_API_HOSTNAME = "https://api.transifex.com"
+API_USERNAME = api.Api.USERNAME
 
 
 class Project(object):
@@ -111,7 +112,7 @@ class Project(object):
         if 'TX_TOKEN' in os.environ:
             # User api info from environment variable
             password = os.environ['TX_TOKEN']
-            username = 'api'
+            username = API_USERNAME
             """We need to check if hostname info exists in the .transifexrc file
             If not, it means that this is the first time this function runs, so
             we need to create its data.
@@ -119,14 +120,14 @@ class Project(object):
             save = self._add_host_to_config_file(host)
             if save:
                 logger.info("Using TX_TOKEN environment variable. Credentials "
-                            "in .transifexrc won't be updated")
+                            "won't be saved to .transifexrc.")
                 self.save()
             if token:
                 # Both env and argument given, inform the user
                 logger.warning(
-                    "A token has been found in TX_TOKEN env variable "
-                    "and --token argument. The latter will be ignored and no "
-                    "data will be saved in the .transifexrc file"
+                    "There is a token in the TX_TOKEN env variable and the "
+                    "--token argument. The latter will be ignored and no "
+                    "credentials will be saved to the .transifexrc file."
                 )
             return username, password
 
@@ -138,11 +139,11 @@ class Project(object):
 
         if token:
             password = token
-            username = 'api'
+            username = API_USERNAME
 
         if not (username and password) and not \
                (config_username and config_password):
-            username = 'api'
+            username = API_USERNAME
             password = self._token_prompt(host)
             save = True
         elif config_username and config_password:
@@ -162,7 +163,7 @@ class Project(object):
         # validation and prompt the use for a token if the validation fails
         if only_token and not self.validate_credentials(username, password):
             logger.info("You need a valid api token to proceed")
-            username = 'api'
+            username = API_USERNAME
             password = self._token_prompt(host)
             save = True
 
@@ -196,7 +197,7 @@ class Project(object):
         while not token:
             token = input(utils.color_text(messages.token_msg, COLOR))
             print(utils.color_text("Verifying token...", "YELLOW"))
-            if not self.validate_credentials('api', token, host):
+            if not self.validate_credentials(API_USERNAME, token, host):
                 logger.info(messages.token_validation_failed)
                 token = None
         return token

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -45,7 +45,7 @@ DEFAULT_API_HOSTNAME = "https://api.transifex.com"
 
 
 class Project(object):
-    """Represents an association between the local and
+    """Represent an association between the local and
     remote project instances.
     """
 
@@ -108,32 +108,42 @@ class Project(object):
 
         save = False
         config_username, config_password = None, None
+        if 'TX_TOKEN' in os.environ:
+            # User api info from environment variable
+            password = os.environ['TX_TOKEN']
+            username = 'api'
+            """We need to check if hostname info exists in the .transifexrc file
+            If not, it means that this is the first time this function runs, so
+            we need to create its data.
+            """
+            save = self._add_host_to_config_file(host)
+            if save:
+                logger.info("Using TX_TOKEN environment variable. Credentials "
+                            "in .transifexrc won't be updated")
+                self.save()
+            if token:
+                # Both env and argument given, inform the user
+                logger.warning(
+                    "A token has been found in TX_TOKEN env variable "
+                    "and --token argument. The latter will be ignored and no "
+                    "data will be saved in the .transifexrc file"
+                )
+            return username, password
 
         try:
             config_username = self.txrc.get(host, 'username')
             config_password = self.txrc.get(host, 'password')
-            logger.warn(
-                "Found clear-text credentials in ~/.transifexrc. Storing"
-                " your password in ~/.transifexrc is insecure. Consider"
-                " using the TX_TOKEN environment variable with an API"
-                " token instead.")
         except (configparser.NoOptionError, configparser.NoSectionError):
             save = True
 
         if token:
             password = token
             username = 'api'
-        elif 'TX_TOKEN' in os.environ:
-            password = os.environ['TX_TOKEN']
-            username = 'api'
 
         if not (username and password) and not \
                (config_username and config_password):
             username = 'api'
-            if no_interactive:
-                logger.warn("No credentials configured.")
-            else:
-                password = self._token_prompt(host)
+            password = self._token_prompt(host)
             save = True
         elif config_username and config_password:
             if username == config_username and password == config_password:
@@ -157,14 +167,28 @@ class Project(object):
             save = True
 
         if save:
+            self._add_host_to_config_file(host)
+            self.txrc.set(host, 'username', username)
+            self.txrc.set(host, 'password', password)
+            self.save()
+        return username, password
+
+    def _add_host_to_config_file(self, host):
+        """Check if a given host exists in .transifexrc, and if not it
+        updates the file with the appropriate info.
+
+        :param str host: The hostname to search for and add if needed.
+        :return: True if adding a new host, nothing otherwise.
+        :rtype: bool
+        """
+        if not self.txrc.has_section(host):
             logger.info("Updating %s file..." % self.txrc_file)
-            if not self.txrc.has_section(host):
-                self.txrc.add_section(host)
+            self.txrc.add_section(host)
             self.txrc.set(host, 'hostname', host)
             self.txrc.set(host, 'api_hostname',
                           utils.DEFAULT_HOSTNAMES['api_hostname'])
-            self.save()
-        return username, password
+            return True
+        return False
 
     def _token_prompt(self, host):
         token = None
@@ -203,7 +227,7 @@ class Project(object):
             self.config.set(resource, 'host', host)
 
     def get_resource_host(self, resource):
-        """Returns the host that the resource is configured to use.
+        """Return the host that the resource is configured to use.
         If there is no such option we return the default one.
         """
         return self.config.get('main', 'host')
@@ -898,8 +922,7 @@ class Project(object):
 
         # Read the credentials from the config file (.transifexrc)
         host = self.url_info['host']
-        username, passwd = self.getset_host_credentials(
-            host, no_interactive=True)
+        username, passwd = self.getset_host_credentials(host)
         try:
             hostname = self.txrc.get(host, 'hostname')
         except configparser.NoSectionError:
@@ -1314,14 +1337,12 @@ class Project(object):
         host = self.url_info['host']
         try:
             hostname = self.txrc.get(host, 'hostname')
+            username, passwd = self.getset_host_credentials(host)
         except configparser.NoSectionError:
             raise TransifexrcConfigFileError(
                 "No user credentials found for host %s. Edit "
                 "~/.transifexrc and add the appropriate "
                 "info in there." % host)
-
-        username, passwd = self.getset_host_credentials(
-            host, no_interactive=True)
 
         # Create the Url
         kwargs['hostname'] = hostname


### PR DESCRIPTION
Reverted changes made by previous commits which were forcing the TX_TOKEN environment variable. Now both TX_TOKEN and password in the .transifexrc file are supported.