### PR TITLE
Add the no-interactive flag to the pull command

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -163,7 +163,7 @@ class TestPullCommand(unittest.TestCase):
             branch='a-branch', fetchall=False, fetchsource=False,
             force=False, languages=[], minimum_perc=None, mode=None,
             overwrite=True, pseudo=False, resources=[], skip=False,
-            xliff=False, parallel=False
+            xliff=False, parallel=False, no_interactive=False
         )
         pr_instance.pull.assert_has_calls([pull_call])
 
@@ -182,8 +182,23 @@ class TestPullCommand(unittest.TestCase):
             branch='somebranch', fetchall=False, fetchsource=False,
             force=False, languages=[], minimum_perc=None, mode=None,
             overwrite=True, pseudo=False, resources=[], skip=False,
-            xliff=False, parallel=False
+            xliff=False, parallel=False, no_interactive=False
         )
+        pr_instance.pull.assert_has_calls([pull_call])
+
+    @patch('txclib.commands.project')
+    def test_pull_with_no_interactive(self, project_mock):
+        pr_instance = MagicMock()
+        pr_instance.pull.return_value = True
+        project_mock.Project.return_value = pr_instance
+        cmd_pull(['--no-interactive'], '.')
+        pull_call = call(
+            fetchall=False, force=False, minimum_perc=None,
+            skip=False, no_interactive=True, resources=[], pseudo=False,
+            languages=[], fetchsource=False, mode=None, branch=None,
+            xliff=False, parallel=False, overwrite=True
+        )
+        self.assertEqual(pr_instance.pull.call_count, 1)
         pr_instance.pull.assert_has_calls([pull_call])
 
 

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -453,7 +453,7 @@ def cmd_pull(argv, path_to_tx):
         fetchall=options.fetchall, fetchsource=options.fetchsource,
         force=options.force, skip=skip, minimum_perc=minimum_perc,
         mode=options.mode, pseudo=pseudo, xliff=xliff, branch=branch,
-        parallel=parallel,
+        parallel=parallel, no_interactive=options.no_interactive,
     )
     logger.info("Done.")
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -198,6 +198,9 @@ def pull_parser():
                         "file as xliff.")
     parser.add_argument("--parallel", action="store_true", default=False,
                         help="perform push/pull requests in parallel")
+    parser.add_argument("--no-interactive", action="store_true",
+                        dest="no_interactive", default=False,
+                        help="Don't require user input.")
     return parser
 
 


### PR DESCRIPTION
Checklist (for the reviewer)
----------------------------

* [ ] Problem and solution are well-explained in the PR
* [ ] Change is covered by unit-tests
* [ ] Code is well documented
* [ ] Code is styled well and is following best practices
* [ ] Performs well when applied to big organizations/resources/etc from our production database
* [ ] Errors are handled properly
* [ ] All (conceivable) edge-cases are handled
* [ ] Code is instrumented to report unexpected failures or increases in the failure rate
* [ ] Commits have been squashed so that each one has a clear purpose (and green tests)
* [ ] Proper labels have been applied

Problem
-------
Users need to use the tx pull command without user input.  This is needed in some cases where CI environments need to fail silently.

Steps to reproduce
------------------
- Make sure that TX_TOKEN is not set `unset TX_TOKEN`
- Remove any previous configuration `rm ~/.transifexrc`
- Initialize a new project `tx init --host="https://www.transifex.com" --skipsetup --no-interactive`
- Run config mapping for a resource (ex`tx config mapping -r demo_project.demo -s en 'locale/<lang>/LC_MESSAGES/django.po' -t PO --execute`)
- Run `tx pull`
- Confirm that user input is required.

Solution
--------
Add the --no-interactive argument in the tx pull command. This means that no user input will be required when no token info exists, and the command will raise an error.

Example run / Screenshots
-------------------------

Performance on live data
------------------------