### PR TITLE
Make the initialization wizard fail if no suitable formats are found

### DIFF
--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -3,6 +3,8 @@
 import unittest
 from mock import patch, MagicMock
 
+from six import assertRaisesRegex
+
 from txclib.wizard import Wizard
 
 
@@ -95,6 +97,27 @@ class WizardCase(unittest.TestCase):
             [("INI", "Joomla INI File - .ini"),
              ("SRT", "SubRip subtitles - .srt")]
         )
+
+    def test_unsupported_formats(self, api_mock):
+        self.wizard.api.get.return_value = {
+            "INI": {
+                "mimetype": "text/plain",
+                "file-extensions": ".ini",
+                "description": "Joomla INI File"
+            },
+            "SRT": {
+                "mimetype": "text/plain",
+                "file-extensions": ".srt",
+                "description": "SubRip subtitles"
+            }
+        }
+        error_msg = "No formats found for this file"
+        with assertRaisesRegex(self, Exception, error_msg):
+            self.wizard.get_formats('test.srt.txt')
+        with assertRaisesRegex(self, Exception, error_msg):
+            self.wizard.get_formats('test.init')
+        with assertRaisesRegex(self, Exception, error_msg):
+            self.wizard.get_formats('test.txt')
 
     @patch('txclib.wizard.os.path.isfile')
     def test_run(self, api_mock, isfile_mock):

--- a/txclib/messages.py
+++ b/txclib/messages.py
@@ -64,6 +64,7 @@ Here’s a list of the supported file formats. For more information,
 check our docs at https://docs.transifex.com/formats/.
 """),
         "error": "Error: Invalid choice. Enter the number corresponding with the format you wish to select.",
+        "empty": "No formats found for this file extension. For more information, check our docs at https://docs.transifex.com/formats/",
         "message": "[?] Select the file format type [{r}]: ",
     },
     "organization": {

--- a/txclib/wizard.py
+++ b/txclib/wizard.py
@@ -122,6 +122,8 @@ class Wizard(object):
 
         formats = [(k, display_format(v)) for k, v in formats.items()
                    if extension in v['file-extensions']]
+        if not formats:
+            raise Exception(messages.TEXTS['formats']['empty'])
         return sorted(formats, key=lambda x: x[0])
 
     def run(self):


### PR DESCRIPTION
While initializing a Transifex project with the wizard, we no longer proceed if the file extension does not match any of our supported file formats.