### PR TITLE
Fix log level of remote lang to local path message

### DIFF
--- a/txclib/project.py
+++ b/txclib/project.py
@@ -544,7 +544,7 @@ class Project(object):
                 if not overwrite:
                     local_file += ".new"
 
-                logger.warning(
+                logger.info(
                     " -> %s: %s" % (utils.color_text(remote_lang, "RED"),
                                     local_file)
                 )


### PR DESCRIPTION
PR https://github.com/transifex/transifex-client/pull/238 fixes an issue we had for ages, where an INFO message was treated as a WARNING, showing a warning message on every `tx pull`. The issue was introduced back in 2012 (https://github.com/transifex/transifex-client/commit/d8add0c03a2ca2f48972cd7ab54ec4c906e49bb9), probably due to copying and pasting.

The original PR was missing the ENV variables added by the CircleCI (because the user opened the PR from a forked repo) so the tests were failing.

Message from the original PR: 
Fixes #237.