### PR TITLE
[DNM]Fix issue with pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3<1.24
-six==1.11.0
+urllib3<=1.24
+six<=1.11
 requests>=2.19.1,<3.0.0
-python-slugify==1.2.6
+python-slugify<=1.2


### PR DESCRIPTION
Pinning dependencies in a specific version break compatibility with 3rd party integrations. In order to fix that, we remove any hardcoded  minor versions and replace the hard dependency with an upper limit one.

This fixes https://github.com/transifex/transifex-client/issues/211#issuecomment-443416109 and https://github.com/transifex/transifex-client/issues/252 where the Transifex client could not be installed due to hard pinned dependencies.