### PR TITLE
Pin to major version but not to minor or patch.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3<1.24
-six==1.11.0
+urllib3>=1.24.2,<2.0.0
+six<2.0.0
 requests>=2.19.1,<3.0.0
-python-slugify==1.2.6
+python-slugify<2.0.0


### PR DESCRIPTION
Since this gets pulled into setup.py  people who install this client into the same
venv as others are limited to only these versions.  Be more flexible here without
losing the value of pinning.

Require urllib3>1.24.2 because older versions have a security vulnerability.