### PR TITLE
Security related update for urllib3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --user --upgrade pip==9.0.3"
-  - "python -m pip install pyinstaller"
+  - "python -m pip install pyinstaller==3.4"
 
   # Set up the project in develop mode. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3<1.24
+urllib3>=1.24.2,<1.25
 six==1.11.0
 requests>=2.19.1,<3.0.0
 python-slugify==1.2.6


### PR DESCRIPTION
Bump of urllib3 version due to security update.

```
CVE-2019-11324
More information
high severity
Vulnerable versions: < 1.24.2
Patched version: 1.24.2

The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired 
set of CA certificates is different from the OS store of CA certificates, which results in SSL
connections succeeding in situations where a verification failure is the correct outcome. 
This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument.
```