### PR TITLE
Fix version of pyinstaller in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --user --upgrade pip==9.0.3"
-  - "python -m pip install pyinstaller"
+  - "python -m pip install pyinstaller==3.4"
 
   # Set up the project in develop mode. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,


### PR DESCRIPTION
pyinstaller 3.5 released in 2019-07-09 breaks the Windows build.