### PR TITLE
Support Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
       TOX_PY2: 2.7.13
-      TOX_PY3: 3.7.0
+      TOX_PY3: 3.8.0
     # To see the list of pre-built images that CircleCI provides for most
     # common languages see
     # https://circleci.com/docs/2.0/circleci-images/

--- a/contrib/tx_commands.sh
+++ b/contrib/tx_commands.sh
@@ -1,6 +1,8 @@
 if [[ -z "$TRANSIFEX_USER" || -z "$TRANSIFEX_TOKEN" || -z "$TRANSIFEX_PROJECT" ]] ; then
     echo "NB: Skipping tests of $TX since TRANSIFEX_USER or TRANSIFEX_TOKEN or TRANSIFEX_PROJECT is undefined or empty"
-    test "${CIRCLE_BRANCH}" = master
+
+    # TRANSIFEX_ ENV variables are not expected for pull requests or local builds
+    [[ "${CIRCLE_BRANCH+x}" != x || "${CIRCLE_BRANCH}" == master || "${CIRCLE_BRANCH}" =~ ^pull/.* ]]
     exit $?
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license="GPLv2",
     dependency_links=[],
     setup_requires=[],
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.8",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.9",
     install_requires=get_file_content("requirements.txt").splitlines(),
     tests_require=["mock"],
     data_files=[],
@@ -40,5 +40,6 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,37}-{vanilla,pyopenssl}
+envlist = py{27,38}-{vanilla,pyopenssl}
 
 [testenv]
 deps =
@@ -12,6 +12,6 @@ install_command = pip install -U {opts} {packages}
 setenv = TOX_ENV_NAME={envname}
 passenv = TOX_* TRANSIFEX_USER TRANSIFEX_TOKEN TRANSIFEX_PROJECT CI CI_* CIRCLECI CIRCLE* APPVEYOR* TERM*
 commands = python -V
-           coverage run --append setup.py test
+           coverage run --source txclib setup.py test
            bash ./contrib/test_build.sh
-           codecov -e TOX_ENV_NAME
+           bash -c 'test -n "$CI" && codecov -e TOX_ENV_NAME || coverage report'

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,6 @@ install_command = pip install -U {opts} {packages}
 setenv = TOX_ENV_NAME={envname}
 passenv = TOX_* TRANSIFEX_USER TRANSIFEX_TOKEN TRANSIFEX_PROJECT CI CI_* CIRCLECI CIRCLE* APPVEYOR* TERM*
 commands = python -V
-           coverage run --source txclib setup.py test
+           coverage run setup.py test
            bash ./contrib/test_build.sh
-           bash -c 'test -n "$CI" && codecov -e TOX_ENV_NAME || coverage report'
+           bash -c 'test -n "$CI" && codecov -e TOX_ENV_NAME'


### PR DESCRIPTION
This PR continues on PR https://github.com/transifex/transifex-client/pull/266 which had failing CircleCI tests (because environment variables are not being copied across forked repositories).