### PR TITLE
Don't pin six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 urllib3>=1.24.2,<1.25
-six==1.11.0
+six>=1.11.0,<2.0.0
 requests>=2.19.1,<3.0.0
 python-slugify==1.2.6


### PR DESCRIPTION
With that it make impossible (especially with pipenv) to install with an other package that requires
a higher version of six.