### PR TITLE
Loosen up dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3>=1.24.2,<1.25
-six==1.11.0
+urllib3>=1.24.2,<2.0.0
+six<2.0.0
 requests>=2.19.1,<3.0.0
-python-slugify==1.2.6
+python-slugify<2.0.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,7 +79,7 @@ class MakeRequestTestCase(unittest.TestCase):
 
         # Test http
         host = 'http://whynotestsforthisstuff.com'
-        with patch.dict(os.environ, {'http_proxy': 'host:333'}):
+        with patch.dict(os.environ, {'http_proxy': 'proxy.host:333'}):
             utils.make_request(
                 'GET',
                 host,
@@ -89,12 +89,12 @@ class MakeRequestTestCase(unittest.TestCase):
             )
             mock_manager.assert_called_once_with(num_pools=1,
                                                  proxy_headers=Any(),
-                                                 proxy_url='http://host:333')
+                                                 proxy_url='http://proxy.host:333')
             mock_connection.request.assert_called_once()
 
         # Test https
         host = 'https://whynotestsforthisstuff.com'
-        with patch.dict(os.environ, {'https_proxy': 'host:333'}):
+        with patch.dict(os.environ, {'https_proxy': 'proxy.host:333'}):
             utils.make_request(
                 'GET',
                 host,
@@ -104,7 +104,7 @@ class MakeRequestTestCase(unittest.TestCase):
             )
             mock_manager.assert_called_with(num_pools=1,
                                             proxy_headers=Any(),
-                                            proxy_url='https://host:333',
+                                            proxy_url='https://proxy.host:333',
                                             ca_certs=Any(),
                                             cert_reqs=Any())
             self.assertEqual(mock_connection.request.call_count, 2)


### PR DESCRIPTION
~~It also bumps `urllib3` minimum version required to `1.24.3`, as the previous versions have a security concern (CVE-2019-11324)~~. 

Actually urllib3 `1.24.2` is fine, so no minimum version bump needed.