### PR TITLE
Fix the symlink push issue

### DIFF
--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -505,8 +505,9 @@ def get_project_files(curpath, expression):
             continue
 
         for file_path in files:
+            path_to_match = os.path.join(root, file_path)
             full_path = os.path.realpath(os.path.join(root, file_path))
-            match = expression_regex.match(posix_path(full_path))
+            match = expression_regex.match(posix_path(path_to_match))
             if match:
                 try:
                     lang = match.group(1)


### PR DESCRIPTION
Symbolic links used not to be correctly asserted in the manner of matching the user-defined regular expressions. Thus symlinking translation files into the initial set up project directory ended to translation files not being able to be uploaded.