### PR TITLE
Fixing a symlink issue

### DIFF
--- a/txclib/__init__.py
+++ b/txclib/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 # https://www.python.org/dev/peps/pep-0440/#examples-of-compliant-version-schemes
-__version__ = '0.13.8'
+__version__ = '0.13.9'

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -495,12 +495,12 @@ def get_project_files(curpath, expression):
     expr_re = regex_from_filefilter(os.path.join(*expression_parts), curpath)
     expression_regex = re.compile(expr_re)
 
-    visited = set()
+    initial_depth = curpath.count(os.sep)
+    max_depth = 50
     for root, dirs, files in os.walk(curpath, followlinks=True):
-        root_realpath = os.path.realpath(root)
 
         # Don't visit any subdirectory
-        if root_realpath in visited:
+        if root.count(os.sep) > initial_depth + max_depth:
             del dirs[:]
             continue
 
@@ -517,16 +517,6 @@ def get_project_files(curpath, expression):
                     raise MalformedConfigFile(msg)
                 yield full_path, lang
 
-        visited.add(root_realpath)
-
-        # Find which directories are already visited and remove them from
-        # further processing
-        removals = list(
-            d for d in dirs
-            if os.path.realpath(os.path.join(root, d)) in visited
-        )
-        for removal in removals:
-            dirs.remove(removal)
 
 
 def encode_args(func):


### PR DESCRIPTION
We had an issue reported where having a symlinked directory caused a language to not be detected.

This ended up being due to having added provisions for not going into infinite loops due to symlinks.

We would visit each "real" subdirectory only once, which meant that if you have 10 directories symlinked with different names, only the first one would be picked up as a candidate and assigned the language the name pointed to. The others would be ignored.

Changed this to a max-depth approach to instead stop infinite loops this way.