### PR TITLE
Flag for comparing file timestamp through git

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ urllib3>=1.24.2,<2.0.0
 six<2.0.0
 requests>=2.19.1,<3.0.0
 python-slugify<2.0.0
+gitpython

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ urllib3>=1.24.2,<2.0.0
 six<2.0.0
 requests>=2.19.1,<3.0.0
 python-slugify<2.0.0
-gitpython
+gitpython<4.0.0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -204,6 +204,22 @@ class TestPullCommand(unittest.TestCase):
         self.assertEqual(pr_instance.pull.call_count, 1)
         pr_instance.pull.assert_has_calls([pull_call])
 
+    @patch('txclib.commands.project')
+    def test_pull_with_git_timestamps(self, project_mock):
+        pr_instance = MagicMock()
+        pr_instance.pull.return_value = True
+        project_mock.Project.return_value = pr_instance
+        cmd_pull(['--use-git-timestamps'], '.')
+        pull_call = call(
+            fetchall=False, force=False, minimum_perc=None,
+            skip=False, no_interactive=False, resources=[], pseudo=False,
+            languages=[], fetchsource=False, mode=None, branch=None,
+            xliff=False, parallel=False, overwrite=True,
+            use_git_timestamps=True
+        )
+        self.assertEqual(pr_instance.pull.call_count, 1)
+        pr_instance.pull.assert_has_calls([pull_call])
+
 
 class TestConfigCommand(unittest.TestCase):
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -163,7 +163,8 @@ class TestPullCommand(unittest.TestCase):
             branch='a-branch', fetchall=False, fetchsource=False,
             force=False, languages=[], minimum_perc=None, mode=None,
             overwrite=True, pseudo=False, resources=[], skip=False,
-            xliff=False, parallel=False, no_interactive=False
+            xliff=False, parallel=False, no_interactive=False,
+            use_git_timestamps=False
         )
         pr_instance.pull.assert_has_calls([pull_call])
 
@@ -182,7 +183,8 @@ class TestPullCommand(unittest.TestCase):
             branch='somebranch', fetchall=False, fetchsource=False,
             force=False, languages=[], minimum_perc=None, mode=None,
             overwrite=True, pseudo=False, resources=[], skip=False,
-            xliff=False, parallel=False, no_interactive=False
+            xliff=False, parallel=False, no_interactive=False,
+            use_git_timestamps=False
         )
         pr_instance.pull.assert_has_calls([pull_call])
 
@@ -196,7 +198,8 @@ class TestPullCommand(unittest.TestCase):
             fetchall=False, force=False, minimum_perc=None,
             skip=False, no_interactive=True, resources=[], pseudo=False,
             languages=[], fetchsource=False, mode=None, branch=None,
-            xliff=False, parallel=False, overwrite=True
+            xliff=False, parallel=False, overwrite=True,
+            use_git_timestamps=False
         )
         self.assertEqual(pr_instance.pull.call_count, 1)
         pr_instance.pull.assert_has_calls([pull_call])

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -706,10 +706,10 @@ class TestProjectPull(unittest.TestCase):
 
             with patch.object(utils, 'get_git_file_timestamp') as ts_mock:
                 # Note that the test needs an existing file path
-                # and the current test file is the only one
-                # we're sure will exist
+                # The current test (__file__) is the only file
+                # we're sure will exist and won't change
 
-                # very old timestamp
+                # Old timestamp (1990)
                 ts_mock.return_value = 640124371
                 res = self.p._should_download(
                     'pt', self.stats, os.path.abspath(__file__), False,
@@ -717,7 +717,7 @@ class TestProjectPull(unittest.TestCase):
                 )
                 self.assertEqual(res, True)
 
-                # Please fix this test before the year 2100
+                # "Recent" timestamp (in the future - 2100)
                 ts_mock.return_value = 4111417171
                 res = self.p._should_download(
                     'pt', self.stats, os.path.abspath(__file__), False,

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -704,6 +704,27 @@ class TestProjectPull(unittest.TestCase):
                 res = self.p._should_download('pt', self.stats, None, True)
                 self.assertEqual(res, True)
 
+            with patch.object(utils, 'get_git_file_timestamp') as ts_mock:
+                # Note that the test needs an existing file path
+                # and the current test file is the only one
+                # we're sure will exist
+
+                # very old timestamp
+                ts_mock.return_value = 640124371
+                res = self.p._should_download(
+                    'pt', self.stats, os.path.abspath(__file__), False,
+                    use_git_timestamps=True
+                )
+                self.assertEqual(res, True)
+
+                # Please fix this test before the year 2100
+                ts_mock.return_value = 4111417171
+                res = self.p._should_download(
+                    'pt', self.stats, os.path.abspath(__file__), False,
+                    use_git_timestamps=True
+                )
+                self.assertEqual(res, False)
+
     def test_get_url_by_pull_mode(self):
         self.assertEqual(
             'pull_sourceastranslation_file',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -376,11 +376,11 @@ class GitUtilsTestCase(unittest.TestCase):
         )
         self.assertIsNotNone(epoch_ts)
 
-    def git_timestamp_is_parsable(self):
+    def test_git_timestamp_is_parsable(self):
         # A bit meta, lets try to get the timestamp of the
         # current file
         epoch_ts = utils.get_git_file_timestamp(
             os.path.dirname(os.path.abspath(__file__))
         )
-        parsed_ts = time.mktime(time.gmtime(epoch_ts))
-        self.assertIsNotNone(parsed_ts)
+        time.mktime(time.gmtime(epoch_ts))
+        self.assertIsNotNone(epoch_ts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -382,5 +382,5 @@ class GitUtilsTestCase(unittest.TestCase):
         epoch_ts = utils.get_git_file_timestamp(
             os.path.dirname(os.path.abspath(__file__))
         )
-        time.mktime(time.gmtime(epoch_ts))
-        self.assertIsNotNone(epoch_ts)
+        parsed_ts = time.mktime(time.gmtime(epoch_ts))
+        self.assertIsNotNone(parsed_ts)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 import six
 from mock import patch, MagicMock, mock_open
@@ -364,3 +365,22 @@ class ProjectFilesTestCase(unittest.TestCase):
         with six.assertRaisesRegex(self, exceptions.MalformedConfigFile, msg):
             for file, lang in utils.get_project_files(os.getcwd(), expression):
                 pass
+
+class GitUtilsTestCase(unittest.TestCase):
+
+    def test_fetch_timestamp_from_git_tree(self):
+        # A bit meta, lets try to get the timestamp of the
+        # current file
+        epoch_ts = utils.get_git_file_timestamp(
+            os.path.dirname(os.path.abspath(__file__))
+        )
+        self.assertIsNotNone(epoch_ts)
+
+    def git_timestamp_is_parsable(self):
+        # A bit meta, lets try to get the timestamp of the
+        # current file
+        epoch_ts = utils.get_git_file_timestamp(
+            os.path.dirname(os.path.abspath(__file__))
+        )
+        parsed_ts = time.mktime(time.gmtime(epoch_ts))
+        self.assertIsNotNone(parsed_ts)

--- a/txclib/commands.py
+++ b/txclib/commands.py
@@ -414,6 +414,7 @@ def cmd_push(argv, path_to_tx):
     skip = options.skip_errors
     xliff = options.xliff
     parallel = options.parallel
+    use_git_timestamps = options.use_git_timestamps
     prj = project.Project(path_to_tx)
     if not (options.push_source or options.push_translations):
         parser.error("You need to specify at least one of the -s|--source, "
@@ -425,7 +426,8 @@ def cmd_push(argv, path_to_tx):
         skip=skip, source=options.push_source,
         translations=options.push_translations,
         no_interactive=options.no_interactive,
-        xliff=xliff, branch=branch, parallel=parallel
+        xliff=xliff, branch=branch, parallel=parallel,
+        use_git_timestamps=use_git_timestamps,
     )
     logger.info("Done.")
 
@@ -445,6 +447,7 @@ def cmd_pull(argv, path_to_tx):
     parallel = options.parallel
     skip = options.skip_errors
     minimum_perc = options.minimum_perc or None
+    use_git_timestamps = options.use_git_timestamps
 
     _go_to_dir(path_to_tx)
 
@@ -457,6 +460,7 @@ def cmd_pull(argv, path_to_tx):
         force=options.force, skip=skip, minimum_perc=minimum_perc,
         mode=options.mode, pseudo=pseudo, xliff=xliff, branch=branch,
         parallel=parallel, no_interactive=options.no_interactive,
+        use_git_timestamps=use_git_timestamps
     )
     logger.info("Done.")
 

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -185,8 +185,8 @@ def pull_parser():
     parser.add_argument("--use-git-timestamps", action="store_true",
                         dest="use_git_timestamps", default=False,
                         help="Compare local files to their Transifex version "
-                        "by their latest commit timestamps. Use this when "
-                        "cloning local files from a Git repository.")
+                        "by their latest commit timestamps. Use this option, "
+                        "for example, when cloning a Git repository.")
     parser.add_argument(
         "--mode", action="store", dest="mode", help=(
             "Specify the mode of the translation file to pull (e.g. "
@@ -252,8 +252,8 @@ def push_parser():
     parser.add_argument("--use-git-timestamps", action="store_true",
                         dest="use_git_timestamps", default=False,
                         help="Compare local files to their Transifex version "
-                        "by their latest commit timestamps. Use this when "
-                        "cloning local files from a Git repository.")
+                        "by their latest commit timestamps. Use this option, "
+                        "for example, when cloning a Git repository.")
     parser.add_argument(
         "-b", "--branch", action="store", dest="branch",
         default=None, nargs="?", const='-1',

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -182,6 +182,9 @@ def pull_parser():
     parser.add_argument("--pseudo", action="store_true", dest="pseudo",
                         default=False, help="Apply this option to download "
                         "a pseudo file.")
+    parser.add_argument("--use-git-timestamps", action="store_true",
+                        dest="use_git_timestamps", default=False,
+                        help="Compare files by their latest commit timestamps.")
     parser.add_argument(
         "--mode", action="store", dest="mode", help=(
             "Specify the mode of the translation file to pull (e.g. "
@@ -244,6 +247,9 @@ def push_parser():
     parser.add_argument("-x", "--xliff", action="store_true", dest="xliff",
                         default=False, help="Apply this option to upload "
                         "file as xliff.")
+    parser.add_argument("--use-git-timestamps", action="store_true",
+                        dest="use_git_timestamps", default=False,
+                        help="Compare files by their latest commit timestamps.")
     parser.add_argument(
         "-b", "--branch", action="store", dest="branch",
         default=None, nargs="?", const='-1',

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -184,7 +184,9 @@ def pull_parser():
                         "a pseudo file.")
     parser.add_argument("--use-git-timestamps", action="store_true",
                         dest="use_git_timestamps", default=False,
-                        help="Compare files by their latest commit timestamps.")
+                        help="Compare local files to their Transifex version "
+                        "by their latest commit timestamps. Use this when "
+                        "cloning local files from a Git repository.")
     parser.add_argument(
         "--mode", action="store", dest="mode", help=(
             "Specify the mode of the translation file to pull (e.g. "
@@ -249,7 +251,9 @@ def push_parser():
                         "file as xliff.")
     parser.add_argument("--use-git-timestamps", action="store_true",
                         dest="use_git_timestamps", default=False,
-                        help="Compare files by their latest commit timestamps.")
+                        help="Compare local files to their Transifex version "
+                        "by their latest commit timestamps. Use this when "
+                        "cloning local files from a Git repository.")
     parser.add_argument(
         "-b", "--branch", action="store", dest="branch",
         default=None, nargs="?", const='-1',

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -1123,8 +1123,8 @@ class Project(object):
             )
             if len(commits_touching_path) > 0:
                 latest_commit = commits_touching_path[0]
-                tatest_commit_tx = latest_commit.committed_date
-                return time.mktime(time.gmtime(tatest_commit_tx))
+                latest_commit_ts = latest_commit.committed_date
+                return time.mktime(time.gmtime(latest_commit_ts))
             else:
                 # Fallback to file OS timestamp
                 time.mktime(time.gmtime(os.path.getmtime(path)))

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -1006,6 +1006,9 @@ class Project(object):
             local_file: The local translation file.
             force: A boolean flag.
             mode: The mode for the translation.
+            use_git_timestamps: Boolean flag -  use latest commit timestamp
+                instead of system timestamps for checking if local file is
+                older than Transifex's.
         Returns:
             True or False.
         """
@@ -1024,6 +1027,9 @@ class Project(object):
             stats: The (global) statistics object.
             force: A boolean flag.
             mode: The mode for the translation.
+            use_git_timestamps: Boolean flag -  use latest commit timestamp
+                instead of system timestamps for checking if local file is
+                older than Transifex's.
         Returns:
             True or False.
         """
@@ -1071,6 +1077,9 @@ class Project(object):
             stats: The (global) statistics object.
             local_file: The local translation file.
             force: A boolean flag.
+            use_git_timestamps: Boolean flag -  use latest commit timestamp
+                instead of system timestamps for checking if local file is
+                older than Transifex's.
         Returns:
             True or False.
         """
@@ -1111,6 +1120,9 @@ class Project(object):
 
         Args:
             path: The path we want the mtime for.
+            use_git_timestamps: Boolean flag -  use latest commit timestamp
+                instead of system timestamps for checking if local file is
+                older than Transifex's.
         Returns:
             The time as a timestamp or None, if the file does not exist
         """

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import git
 import fnmatch
 import datetime
 import time
@@ -1117,19 +1116,11 @@ class Project(object):
             return None
 
         if use_git_timestamps:
-            repo = git.Repo()
-            commits_touching_path = list(
-                repo.iter_commits(paths=path)
-            )
-            if len(commits_touching_path) > 0:
-                latest_commit = commits_touching_path[0]
-                latest_commit_ts = latest_commit.committed_date
-                return time.mktime(time.gmtime(latest_commit_ts))
-            else:
-                # Fallback to file OS timestamp
-                time.mktime(time.gmtime(os.path.getmtime(path)))
-        else:
-            return time.mktime(time.gmtime(os.path.getmtime(path)))
+            epoch_timestamp = utils.get_git_file_timestamp(path)
+            if epoch_timestamp:
+                return time.mktime(time.gmtime(epoch_timestamp))
+
+        return time.mktime(time.gmtime(os.path.getmtime(path)))
 
     def _satisfies_min_translated(self, stats, mode=None):
         """Check whether a translation fulfills the filter used for

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -1126,7 +1126,8 @@ class Project(object):
                 tatest_commit_tx = latest_commit.committed_date
                 return time.mktime(time.gmtime(tatest_commit_tx))
             else:
-                return None
+                # Fallback to file OS timestamp
+                time.mktime(time.gmtime(os.path.getmtime(path)))
         else:
             return time.mktime(time.gmtime(os.path.getmtime(path)))
 

--- a/txclib/project.py
+++ b/txclib/project.py
@@ -1172,6 +1172,9 @@ class Project(object):
             remote_updated: The date and time the translation was last
                 updated remotely.
             local_file: The local file.
+            use_git_timestamps: Boolean flag -  use latest commit timestamp
+                instead of system timestamps for checking if local file is
+                older than Transifex's.
         Returns:
             True or False.
         """

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -737,6 +737,9 @@ def update_progress(done, total):
 
 
 def get_git_file_timestamp(file_path):
+    """
+    Return the timestamp (epoch) for the latest commit of a file
+    """
     try:
         repo = git.Repo()
         commits_touching_path = list(

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -3,6 +3,7 @@ import functools
 import os
 import sys
 import re
+import git
 import errno
 import urllib3
 import collections
@@ -733,3 +734,20 @@ def update_progress(done, total):
     # Print a new line when done
     if done == total:
         sys.stdout.write('\n')
+
+
+def get_git_file_timestamp(file_path):
+    try:
+        repo = git.Repo()
+        commits_touching_path = list(
+            repo.iter_commits(paths=file_path, max_count=1)
+        )
+        if commits_touching_path:
+            latest_commit = commits_touching_path[0]
+            latest_commit_ts = latest_commit.committed_date
+            return latest_commit_ts
+        else:
+            return None
+    except git.InvalidGitRepositoryError:
+        # Current path is not a git repo.
+        return None


### PR DESCRIPTION
Attempt at solving #22 

We had this issue because we're running tx client inside a github action -- https://github.com/sergioisidoro/github-transifex-action --, which will clone the repository from scratch. This means the OS timestamp is always newer than the one in transifex.

This PR adds support for fetching the timestamp of a file form the last commit for that file.

TODO: 

- [x] Error handling in case repository is not found
- [x] Testing
- [x] Check if the packaged lib will pick the correct repo of the current directory
