### PR TITLE
Bump constraint for python-slugify dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --user --upgrade pip"
-  - "python -m pip install --no-use-pep517 pyinstaller==3.4"
+  - "python -m pip install --no-use-pep517 pyinstaller==3.6"
 
   # Set up the project in develop mode. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,

--- a/contrib/tx.spec
+++ b/contrib/tx.spec
@@ -26,4 +26,4 @@ exe = EXE(pyz,
           debug=False,
           strip=None,
           upx=False,
-          console=True , icon='contrib/tx.ico')
+          console=True , icon='tx.ico')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urllib3>=1.24.2,<2.0.0
 six<2.0.0
 requests>=2.19.1,<3.0.0
-python-slugify<2.0.0
+python-slugify<5.0.0
 gitpython<4.0.0


### PR DESCRIPTION
If merged this would solve this https://github.com/transifex/transifex-client/issues/281.

I had to upgrade pyinstaller to have the hook added in this [PR](https://github.com/pyinstaller/pyinstaller/pull/4530)  for text_unidecode a dependency of python-slugify>=2.0.0

I also changed the path since  pyinstaller>=3.5 added support for relative paths https://github.com/pyinstaller/pyinstaller/pull/3444 and the previous configuration was throwing 

```
IOError: [Errno 2] No such file or directory: 'contrib\\contrib/tx.ico'
```

You can see that in https://ci.appveyor.com/project/transifex/transifex-client/builds/33350716/job/dbs7ufhkj4ajfoy1