### PR TITLE
CLI option for custom CA certificate bundle file

### DIFF
--- a/txclib/cmdline.py
+++ b/txclib/cmdline.py
@@ -4,7 +4,7 @@
 import sys
 from urllib3.exceptions import SSLError
 
-from txclib import utils
+from txclib import utils, web
 from txclib.log import set_log_level, logger
 from txclib.parsers import tx_main_parser
 from txclib.exceptions import AuthenticationError
@@ -61,6 +61,8 @@ def main(argv=None):
         set_log_level('WARNING')
     elif options.debug:
         set_log_level('DEBUG')
+
+    web.cacerts_file = options.cacert
 
     # find .tx
     path_to_tx = options.root_dir or utils.find_dot_tx()

--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import argparse
 import os
 import sys
 
@@ -10,6 +11,11 @@ from txclib.utils import get_version
 MAPPING, MAPPINGREMOTE, MAPPINGBULK = (
     'mapping', 'mapping-remote', 'mapping-bulk'
 )
+
+def check_file_exists(file=None):
+    if file and not os.path.isfile(file):
+        raise argparse.ArgumentTypeError(
+            'certificate file %s not found' % file)
 
 
 def tx_main_parser():
@@ -45,6 +51,12 @@ def tx_main_parser():
         "--disable-colors", action="store_true", dest="color_disable",
         default=(os.name == 'nt' or not sys.stdout.isatty()),
         help="disable colors in the output of commands"
+    )
+    # set a private CA cert bundle file to override the system one
+    parser.add_argument(
+        "--cacert", action="store", dest="cacert", default=None,
+        help="set path to CA certificate bundle file",
+        metavar='/path/to/ca-cert-bundle-file', type=check_file_exists
     )
     parser.add_argument(
         "command", action="store", help="TX command", nargs='?', default=None

--- a/txclib/web.py
+++ b/txclib/web.py
@@ -6,6 +6,8 @@ from pkg_resources import resource_filename
 import txclib
 
 
+cacerts_file = None
+
 def user_agent_identifier():
     """Return the user agent for the client."""
     client_info = (txclib.__version__, platform.system(), platform.machine())
@@ -13,6 +15,10 @@ def user_agent_identifier():
 
 
 def certs_file():
+    return cacerts_file or system_certs_file()
+
+
+def system_certs_file():
     if platform.system() == 'Windows':
         return os.path.join(txclib.utils.get_base_dir(), 'cacert.pem')
     else:


### PR DESCRIPTION
Problem and/or solution
-----------------------
This addresses #91 

We add the option to define a private CA certificate bundle file instead of the default which is to use the system's trust store.

How to test
-----------
Test it with a local existent or not cert file like so:
```
tx pull -a --cacert /etc/ssl/certs/ca-certificates.crt
```