### PR TITLE
Use authored date instead of committed date as git file timestamp

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import os
 import time
 import unittest
 import six
-from mock import patch, MagicMock, mock_open
+from mock import patch, MagicMock, Mock, mock_open
 from urllib3.exceptions import SSLError
 
 from txclib import utils, exceptions
@@ -384,3 +384,12 @@ class GitUtilsTestCase(unittest.TestCase):
         )
         parsed_ts = time.mktime(time.gmtime(epoch_ts))
         self.assertIsNotNone(parsed_ts)
+
+    def test_uses_authorized_date(self):
+        commit = Mock()
+        commit.authored_date = 1590969254
+        commit.committed_date = 1590970456
+        with patch('txclib.utils.git.Repo') as repo:
+            repo.return_value.iter_commits.return_value = [commit]
+            epoch_ts = utils.get_git_file_timestamp('any')
+        self.assertEqual(1590969254, epoch_ts)

--- a/txclib/utils.py
+++ b/txclib/utils.py
@@ -747,7 +747,7 @@ def get_git_file_timestamp(file_path):
         )
         if commits_touching_path:
             latest_commit = commits_touching_path[0]
-            latest_commit_ts = latest_commit.committed_date
+            latest_commit_ts = latest_commit.authored_date
             return latest_commit_ts
         else:
             return None


### PR DESCRIPTION
This ensures expected behaviour for rebased commits.

https://alexpeattie.com/blog/working-with-dates-in-git/