### PR TITLE
Minor missing argument fix

### DIFF
--- a/txclib/parsers.py
+++ b/txclib/parsers.py
@@ -16,6 +16,7 @@ def check_file_exists(file=None):
     if file and not os.path.isfile(file):
         raise argparse.ArgumentTypeError(
             'certificate file %s not found' % file)
+    return file
 
 
 def tx_main_parser():


### PR DESCRIPTION
Forgot returning the cacert path after asserting the cacert file existance. 