### PR TITLE
Fix dependency to mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     setup_requires=[],
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.10",
     install_requires=get_file_content("requirements.txt").splitlines(),
-    tests_require=["mock>=3.0.5,<4.0"],
+    tests_require=["mock>=3.0.5,<4.0; python_version < '3.3'"],
     data_files=[],
     test_suite="tests",
     zip_safe=False,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from mock import MagicMock, patch
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
 
 from txclib.api import Api
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,7 +7,10 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-from mock import patch, MagicMock, call
+try:
+    from unittest.mock import patch, MagicMock, call
+except ImportError:
+    from mock import patch, MagicMock, call
 from six import assertRaisesRegex
 from txclib.commands import _set_source_file, _set_translation, cmd_pull, \
     cmd_init, cmd_config, cmd_status, cmd_help, UnInitializedError

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,7 +2,10 @@
 
 import os
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 from txclib.paths import posix_path, native_path
 
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -13,7 +13,10 @@ except ImportError:
     import ConfigParser as configparser
 
 from functools import wraps
-from mock import Mock, patch, mock_open
+try:
+    from unittest.mock import Mock, patch, mock_open
+except ImportError:
+    from mock import Mock, patch, mock_open
 from collections import namedtuple
 from os.path import dirname
 from sys import modules, version_info

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,10 @@ import os
 import time
 import unittest
 import six
-from mock import patch, MagicMock, Mock, mock_open
+try:
+    from unittest.mock import patch, MagicMock, Mock, mock_open
+except ImportError:
+    from mock import patch, MagicMock, Mock, mock_open
 from urllib3.exceptions import SSLError
 
 from txclib import utils, exceptions

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from mock import patch, MagicMock
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from six import assertRaisesRegex
 


### PR DESCRIPTION
mock is part of Python from version 3.3 on, so it's only required for 2.7