### PR TITLE
Fix test_in_combination_with_force_option on 32 bit systems

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -717,8 +717,8 @@ class TestProjectPull(unittest.TestCase):
                 )
                 self.assertEqual(res, True)
 
-                # "Recent" timestamp (in the future - 2100)
-                ts_mock.return_value = 4111417171
+                # "Recent" timestamp (in the future - 2038)
+                ts_mock.return_value = 2147483000
                 res = self.p._should_download(
                     'pt', self.stats, os.path.abspath(__file__), False,
                     use_git_timestamps=True


### PR DESCRIPTION
The test `test_in_combination_with_force_option` fails on 32 bit systems due to an integer overflow.

> Traceback (most recent call last):
>   File "tests/test_project.py", line 722, in test_in_combination_with_force_option
>     res = self.p._should_download(
>   File "txclib/project.py", line 1061, in _should_download
>     if not self._remote_is_newer(remote_update, local_file, use_git_timestamps):
>   File "txclib/project.py", line 1185, in _remote_is_newer
>     local_time = self._get_time_of_local_file(
>   File "txclib/project.py", line 1135, in _get_time_of_local_file
>     return time.mktime(time.gmtime(epoch_timestamp))
> OverflowError: timestamp out of range for platform time_t

This fix should work at least for the next 17 years.