### PR TITLE
Change download path when supplied language is source language

### DIFF
--- a/txclib/project.py
+++ b/txclib/project.py
@@ -489,7 +489,9 @@ class Project(object):
             new_translations |= new
             logger.debug("Adding to new translations: %s" % new)
 
-            if fetchsource:
+            if fetchsource or slang in languages:
+                new_translations.discard(slang)
+                pull_languages.discard(slang)
                 if sfile and slang not in pull_languages:
                     pull_languages.add(slang)
                 elif slang not in new_translations:


### PR DESCRIPTION
When invoking `pull` command, with the `--language` argument supplied,
it will use the path dictated by the `file_filter` as the download
path for each language.

This behavior is not altered even when the source language is passed
and the source file is downloaded at the path dictated by `file_filter`
and the `source_file` path that is present in the configuration.

With this commit we can that the language passed is the source language
and always store the downloaded file in the `source_file` path
that is present in the configuration

Let's use an example to better illustrate the issue:
config:
```
[project_slug.resource_slug]
file_filter = locale/<lang>/ui.po
source_file = locale/ui.po
source_lang = en
type = PO
```

Existing behavior:
`tx pull --language en`
   => download path = `locale/en/ui.po`

New behavior:
`tx pull --language en`
   => download path = `locale/ui.po`