### PR TITLE
Support all Python versions above 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license="GPLv2",
     dependency_links=[],
     setup_requires=[],
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,<3.10",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=3.4",
     install_requires=get_file_content("requirements.txt").splitlines(),
     tests_require=["mock>=3.0.5,<4.0"],
     data_files=[],
@@ -43,5 +43,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )


### PR DESCRIPTION
Hi,

Python 3.10 is released, and the only thing preventing `transifex-client` from using it is the `setup.py` configuration.

For ease of review I just performed the same changes as https://github.com/transifex/transifex-client/pull/306 .

If it seems reasonable, I'd be glad to update the `python_requires` line to allow all Python versions above 3.4 instead (so I can experiment with 3.11 easier 😊).